### PR TITLE
Allow string check to pass on wildcard

### DIFF
--- a/src/validator.es6
+++ b/src/validator.es6
@@ -1061,7 +1061,7 @@ function checkPropertyType(ref, key, propertyType, resourcePropType){
     switch(propertyType){
         case 'String':  // A 'String' in CF can be an int or something starting with a number, it's a loose check
                         // Check the value starts with a letter or / or _
-            if(!(/^[-\w\/]/.test(val))){
+            if(!(/^[-\w\*\/]/.test(val))){
                 addError('crit', `Expected type String for ${key}, got value '${val}'`, placeInTemplate, `${resourcePropType}.${key}`);
             }
             break;


### PR DESCRIPTION
Wildcards are valid strings, as seen in CloudFront headers:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues.html#cfn-cloudfront-forwardedvalues-headers