### PR TITLE
allow GetAtt to work on with arbitrary attributes on CustomResources

### DIFF
--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -191,6 +191,16 @@ describe('validator', () => {
 
     });
 
+    describe('Fn::GetAtt', () => {
+        it('Fn::GetAtt for an arbitrary attribute on a custom resource should return a mock result', () => {
+            const input = 'testData/valid/yaml/valid_getatt_custom_resource.yaml';
+            let result = validator.validateFile(input);
+            expect(result).to.have.property('templateValid', true);
+            expect(validator.fnGetAtt('Custom', 'SomeAttribute')).to.equal('mockAttr_Custom_SomeAttribute');
+            expect(validator.fnGetAtt('Custom2', 'SomeAttribute')).to.equal('mockAttr_Custom2_SomeAttribute');
+        })
+    })
+
     describe('conditions', () => {
 
         it('1 invalid if condition arguments should return an object with validTemplate = false, 1 crit errors', () => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -865,11 +865,14 @@ function fnJoin(join: any, parts: any){
     return parts.join(join);
 }
 
-function fnGetAtt(reference: string, attribute: string){
+export function fnGetAtt(reference: string, attribute: string){
     if(workingInput['Resources'].hasOwnProperty(reference)){
-        if(workingInput['Resources'][reference]['Attributes'].hasOwnProperty(attribute)){
-            return workingInput['Resources'][reference]['Attributes'][attribute];
-        }
+        const resource = workingInput['Resources'][reference];
+        if (resource['Attributes'].hasOwnProperty(attribute)){
+            return resource['Attributes'][attribute];
+        } else if (resource['Type'].indexOf('Custom::') === 0 || resource['Type'] === 'AWS::CloudFormation::CustomResource') {
+            return `mockAttr_${reference}_${attribute}`;
+        } 
     }
     // Return null if not found
     return null;

--- a/testData/valid/yaml/valid_getatt_custom_resource.yaml
+++ b/testData/valid/yaml/valid_getatt_custom_resource.yaml
@@ -1,0 +1,20 @@
+Resources:
+  Custom:
+    Type: Custom::Dooby
+    Properties:
+      ServiceToken: arn:aws:blahblahblah
+
+  Custom2:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: arn:aws:blahblahblah
+  
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: key1
+          Value: !GetAtt Custom.SomeAttribute
+        - Key: key2
+          Value: !GetAtt Custom2.SomeAttribute
+


### PR DESCRIPTION
Should fix #77 . No way to know what Attributes a CustomResource will have without actually executing it, so it's something we can probably mock.