### PR TITLE
Allow inclusion as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,66 @@ Template invalid!
 ### Features that would be nice, but aren't currently possible
 * Detect conditional required properties (Information doesn't exist in AWS Resource Specification)
 
+### API
+`cfn-lint` can also be used as a Node library:
+```ts
+const cfnLint = require('cfn-lint')
+```
+
+The following methods are considered public:
+
+```ts
+cfnLint.validateFile(fileName: string, options?: ValidationOptions): ValidationResult
+```
+Validates a file, and returns an ValidationResult with the results.
+
+
+```ts
+cfnLint.validateJsonObject(object: any, options?: ValidationOptions): ValidationResult
+```
+Validates an object, and returns an ValidationResult with the results. The object
+is what you might get from `JSON.parse`ing a Cloudformation template.
+
+
+```ts
+interface ValidationOptions {
+  parameters?: {
+    Param1: Param1value,
+    // ...
+  }
+  pseudoParameters?: {
+    'AWS::Region': 'ap-southeast-2',
+    // ...
+  }
+}
+```
+`parameters` get passed into the template's Parameters before validation, and `pseudoParameters` are used to override AWS' pseudo-parameters, like `AWS::Region`, `AWS::AccountId`, etc.
+
+
+```ts
+interface ErrorRecord {
+  message: string,
+  resource: string,
+  documentation: string
+}
+interface ValidationResult {
+  templateValid: boolean,
+  errors: {
+    crit: ErrorRecord[],
+    warn: ErrorRecord[],
+    info: ErrorRecord[]
+  },
+  outputs: {
+      [outputName: string]: string;
+  };
+  exports: {
+      [outputName: string]: string;
+  };
+}
+```
+Represents the result of a validation.
+
+
 ## Deploying your template
 
 CloudFormation tends to involve a bit of trail and error. To enable quick development, 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "type": "git",
     "url": "git+https://github.com/martysweet/cfn-lint.git"
   },
+  "types": "./lib/api.d.ts",
+  "main": "./lib/api.js",
   "bin": {
     "cfn-lint": "./lib/index.js"
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,48 @@
+import validator = require('./validator');
+
+export interface ValidationOptions {
+  parameters: {[parameterName: string]: any}
+  pseudoParameters: {[pseudoParameterName: string]: any}
+}
+
+export type ValidationResult = validator.ErrorObject;
+
+const defaultOptions: ValidationOptions = {
+  parameters: {},
+  pseudoParameters: {}
+}
+
+/**
+ * Synchronously validates a CloudFormation yaml or json file.
+ * @param fileName 
+ * @param options 
+ */
+export function validateFile(fileName: string, options?: Partial<ValidationOptions>): ValidationResult {
+  setupValidator(options);
+  return validator.validateFile(fileName);
+}
+
+/**
+ * Synchronously validates an object. The object should be what you
+ * get from JSON.parse-ing or yaml.load-ing a CloudFormation template.
+ * @param objectToValidate
+ * @param options 
+ */
+export function validateJsonObject(objectToValidate: any, options?: Partial<ValidationOptions>): ValidationResult {
+  setupValidator(options);
+  return validator.validateJsonObject(objectToValidate);
+}
+
+function setupValidator(passedOptions?: Partial<ValidationOptions>) {
+  validator.resetValidator();
+  const options = Object.assign({}, defaultOptions, passedOptions);
+  for (let parameterName in options.parameters) {
+    const parameterValue = options.parameters[parameterName];
+    validator.addParameterValue(parameterName, parameterValue)
+  }
+
+  for (let pseudoName in options.pseudoParameters) {
+    const pseudoValue = options.pseudoParameters[pseudoName];
+    validator.addPseudoValue(pseudoName, pseudoValue)
+  }
+}

--- a/src/awsData.ts
+++ b/src/awsData.ts
@@ -4,13 +4,13 @@ export const awsExtraDocs = require('../data/aws_extra_docs.json') as AWSExtraDo
 
 export type AWSPrimitiveType = 'String' | 'Integer' | 'Boolean' | 'Json';
 
-interface PropertyBase {
+export interface PropertyBase {
     Required: boolean,
     Documentation: string,
     UpdateType: 'Mutable' | 'Immutable' | 'Conditional',
 }
 
-interface PrimitiveProperty extends PropertyBase {
+export interface PrimitiveProperty extends PropertyBase {
     PrimitiveType: AWSPrimitiveType,
 
     Type: undefined
@@ -18,7 +18,7 @@ interface PrimitiveProperty extends PropertyBase {
     PrimitiveItemType: undefined
 }
 
-interface ComplexProperty extends PropertyBase {
+export interface ComplexProperty extends PropertyBase {
     Type: string,
 
     PrimitiveType: undefined
@@ -26,28 +26,28 @@ interface ComplexProperty extends PropertyBase {
     PrimitiveItemType: undefined
 }
 
-interface ListPropertyBase extends PropertyBase {
+export interface ListPropertyBase extends PropertyBase {
     Type: 'List',
     DuplicatesAllowed: boolean,
 
     PrimitiveType: undefined
 }
 
-interface PrimitiveItemType {
+export interface PrimitiveItemType {
     PrimitiveItemType: AWSPrimitiveType,
 
     ItemType: undefined
 }
 
-interface ItemType {
+export interface ItemType {
     ItemType: string,
 
     PrimitiveItemType: undefined
 }
 
-type ListProperty = ListPropertyBase & (PrimitiveItemType | ItemType)
+export type ListProperty = ListPropertyBase & (PrimitiveItemType | ItemType)
 
-interface MapPropertyBase extends PropertyBase {
+export interface MapPropertyBase extends PropertyBase {
     Type: 'Map',
     DuplicatesAllowed: boolean,
 
@@ -55,7 +55,7 @@ interface MapPropertyBase extends PropertyBase {
     ItemType: undefined
 }
 
-type MapProperty = MapPropertyBase & (PrimitiveItemType | ItemType)
+export type MapProperty = MapPropertyBase & (PrimitiveItemType | ItemType)
 
 export type Property = PrimitiveProperty | ComplexProperty | ListProperty | MapProperty
 
@@ -71,18 +71,18 @@ export interface ResourceType {
     AdditionalProperties?: boolean
 }
 
-interface PrimitiveAttribute {
+export interface PrimitiveAttribute {
     ItemType: AWSPrimitiveType
 }
 
-interface ListAttribute {
+export interface ListAttribute {
     Type: 'List',
     PrimitiveItemType: AWSPrimitiveType
 }
 
-type Attribute = PrimitiveAttribute | ListAttribute;
+export type Attribute = PrimitiveAttribute | ListAttribute;
 
-interface AWSResourcesSpecification {
+type AWSResourcesSpecification = {
     PropertyTypes: {[propertyName: string]: ResourcePropertyType}
     ResourceTypes: {[resourceName: string]: ResourceType}
 }

--- a/src/test/apiTest.ts
+++ b/src/test/apiTest.ts
@@ -1,0 +1,56 @@
+import {expect} from 'chai';
+import path = require('path');
+import api = require('../api');
+
+describe('api', () => {
+  describe('validateFile', () => {
+    it('should validate a file', () => {
+      const file = path.join(__dirname, '../../testData/valid/yaml/1.yaml');
+      const result = api.validateFile(file);
+      expect(result).to.have.property('templateValid', true);
+      expect(result.errors.crit).to.have.length(0);
+    });
+
+    it('should pass properties', () => {
+      const file = path.join(__dirname, '../../testData/valid/yaml/2.yaml');
+      const result = api.validateFile(file, {
+        parameters: {
+          CertificateArn: 'arn:aws:something'
+        }
+      });
+      expect(result).to.have.property('templateValid', true);
+      expect(result.errors.crit).to.have.length(0);
+    });
+
+    it('should pass pseudo-parameters', () => {
+      const file = path.join(__dirname, '../../testData/valid/yaml/pseudo-parameters.yaml');
+      const result = api.validateFile(file, {
+        pseudoParameters: {
+          'AWS::AccountId': '000000000000',
+          'AWS::Region': 'us-east-1'
+        }
+      });
+      expect(result).to.have.property('templateValid', true);
+      expect(result.errors.crit).to.have.length(0);
+    });
+
+    it('should reset validator state', () => {
+      const file = path.join(__dirname, '../../testData/valid/yaml/2.yaml');
+      const validator = require('../validator');
+      validator.addParameterValue('CertificateArn', 'arn:aws:something');
+      const result = api.validateFile(file);
+      expect(result).to.have.property('templateValid', false);
+      expect(result.errors.crit).to.have.length(1);
+      expect(result.errors.crit[0].message).to.contain('\'string_input_CertificateArn\'');
+    })
+  });
+
+  describe('validateJsonObject', () => {
+    it('should validate an object', () => {
+      const cfn = require('../../testData/valid/json/1.json');
+      const result = api.validateJsonObject(cfn);
+      expect(result).to.have.property('templateValid', true);
+      expect(result.errors.crit).to.have.length(0);
+    });
+  });
+});

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -512,5 +512,35 @@ describe('validator', () => {
             expect(result['errors']['warn']).to.have.lengthOf(0);
         });
 
+        describe('a template with an output referencing a resource and a resource attribute', () => {
+            let result: any;
+            const input = 'testData/valid/yaml/outputs.yaml';
+            result = validator.validateFile(input);
+
+            it('should result in a valid template', () => {
+                expect(result).to.have.deep.property('templateValid', true);
+            });
+
+            it('should populate errorObject outputs correctly', () => {
+                expect(Object.keys(result['outputs'])).to.have.lengthOf(2);
+                expect(result['outputs']['Bucket']).to.equal('mock-ref-Bucket');
+                expect(result['outputs']['BucketArn']).to.match(/^arn:aws:/);
+            });
+
+            it('should populate errorObject exports correctly', () => {
+                expect(Object.keys(result['exports'])).to.have.lengthOf(1);
+                expect(result['exports']['my-global-bucket-export']).to.match(/^arn:aws:/);
+            });
+        });
+
+        it('a template with an exported output missing a Name should result in validTemplate = false, 1 crit error', () => {
+            const input = 'testData/invalid/yaml/invalid_outputs.yaml';
+            let result = validator.validateFile(input);
+            expect(result).to.have.deep.property('templateValid', false);
+            expect(result['errors']['crit']).to.have.lengthOf(1);
+            expect(result['errors']['crit'][0]).to.have.property('message', 'Output BucketArn exported with no Name');
+            expect(result['errors']['crit'][0]).to.have.property('resource', 'Outputs > BucketArn');
+        })
+
     });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -13,21 +13,31 @@ import docs = require('./docs');
 let parameterRuntimeOverride: {[parameter: string]: string | string[]} = {};
 // Todo: Allow override for RefOverrides ex. Regions
 
-interface ErrorRecord {
+export interface ErrorRecord {
     message: string,
     resource: string,
     documentation: string
 }
 
-let errorObject = {
+export interface ErrorObject {
+    templateValid: boolean,
+    errors: {
+        crit: ErrorRecord[],
+        warn: ErrorRecord[],
+        info: ErrorRecord[]
+    },
+    outputs: {[outputName: string]: string},
+    exports: {[outputName: string]: string}
+}
+let errorObject: ErrorObject = {
     "templateValid": true,
     "errors": {
-        "info": [] as ErrorRecord[],
-        "warn": [] as ErrorRecord[],
-        "crit": [] as ErrorRecord[]
+        "info": [],
+        "warn": [],
+        "crit": []
     },
-    "outputs": {} as {[outputName: string]: string},
-    "exports": {} as {[exportName: string]: string},
+    "outputs": {},
+    "exports": {}
 };
 
 export function resetValidator(){

--- a/testData/invalid/yaml/invalid_outputs.yaml
+++ b/testData/invalid/yaml/invalid_outputs.yaml
@@ -1,0 +1,12 @@
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: MyBucket
+
+Outputs:
+  Bucket:
+    Value: !Ref Bucket
+  BucketArn:
+    Value: !GetAtt Bucket.Arn
+    Export: {}

--- a/testData/valid/yaml/outputs.yaml
+++ b/testData/valid/yaml/outputs.yaml
@@ -1,0 +1,13 @@
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: MyBucket
+
+Outputs:
+  Bucket:
+    Value: !Ref Bucket
+  BucketArn:
+    Value: !GetAtt Bucket.Arn
+    Export:
+      Name: my-global-bucket-export

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,11 @@
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation:  */
+    "lib": ["es6"],                             /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
Fixes #78 - adds outputs to errorObject and allows cfn-lint to be included as a module.

I first just went to set `main: validator.js` in package.json, however I think the way the caller needs to manage the state of the validator (addParameterValue(), validate(), resetValidator()) is too much of an implementation detail. Hence I hit this away in `api.ts` to make the public facing api as small as possible.

I had a brief look at autogenerating documentation with TypeDoc but IMO it's more trouble than it's worth, and I'm not aware of any other tools that do a decent enough job for a small public api. (they all seem to be more geared at documenting the internals of a large project).