### PR TITLE
Fixed build - incompatible "@types/colors" package version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Merge PR #120, fixing dependency issue with "@types/colors"
 
 ## [1.5.1] - 2018-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Merge PR #120, fixing dependency issue with "@types/colors"
 
 ## [1.5.1] - 2018-03-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",
-    "@types/colors": "^1.1.3",
+    "@types/colors": "~1.1.3",
     "@types/commander": "^2.11.0",
     "@types/js-yaml": "^3.9.1",
     "@types/mocha": "^2.2.44",


### PR DESCRIPTION
#119 can be easily solved by forcing the `@types/colors` package to the previous version (1.1.3) and perhaps still accept any future patch-level changes (~1.1.3). 