### PR TITLE
Handle validation exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Merge PR #127, implementing "safer-buffer" polyfill to be compatible with older NodeJS versions
 - Merge PR #126, improving null value validation when null is passed into a template
 
+### Changed
+- Merge PR #124, adding the `--verbose` flag and returning exit code `1` on a fatal exception or parsing error
+
 ## [1.5.1] - 2018-03-12
 ### Added
 - Merge PR #113, adding a Spanish translation for README.md

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Template invalid!
 `--only-guess-parameters <param names>`: Only guess the provided parameters, and disable the guessing of all others without Defaults. A critical error will be raised for missing parameters, as above. e.g.
  - `--only-guess-parameters InstanceType,Memory`
 
+`--verbose`: Provide verbose output and stack traces when template parsing fails.
 
 ### What can cfn-lint do?
 * Read JSON + YAML (Including YAML short form)

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ program
 //  .option('--guess-parameters', 'Guess any parameters that are not explicitely passed in and have no Default. This is the default behaviour.')
     .option('-G, --no-guess-parameters', 'Fail validation if a parameter with no Default is not passed')
     .option('-g, --only-guess-parameters <items>', 'Guess the provided parameters, and fail validation if a parameter with no Default is passed', list)
+    .option('-v, --verbose', 'Verbose error messages')
     .action(function (arg1, arg2) {
         firstArg = arg1;
         secondArg = arg2;
@@ -74,7 +75,17 @@ if(firstArg == "validate"){
         guessParameters
     };
 
-    let result = validator.validateFile(secondArg, options);
+    let result = Object();
+    try {
+      result = validator.validateFile(secondArg, options);
+    } catch(err) {
+      console.log('Unable to parse template!');
+      if (program.verbose) {
+        console.error(err);
+      }
+      process.exit(1);
+    }
+
     // Show the errors
     console.log((result['errors']['info'].length + " infos").grey);
     for(let info of result['errors']['info']){

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,18 @@ if(firstArg == "validate"){
     try {
       result = validator.validateFile(secondArg, options);
     } catch(err) {
-      console.log('Unable to parse template!');
+      let error: string = function(msg: string, errors: any) {
+        for (let error of Object.keys(errors)) {
+          if (RegExp(error).test(msg)) {
+            return errors[error];
+          }
+        }
+        return errors[''];
+      }(err.message, {
+        'Could not find file .*. Check the input path.': 'No such file.',
+        '': 'Unable to parse template! Use --verbose for more information.'
+      });
+      console.log(error);
       if (program.verbose) {
         console.error(err);
       }

--- a/src/test/indexTest.ts
+++ b/src/test/indexTest.ts
@@ -102,18 +102,19 @@ describe('index', () => {
         }).timeout(5000);
 
         it('handle validation exceptions - non-verbose', (done) => {
-            exec('node lib/index.js validate testData/invalid/some_file_that_does_not_exist', function(error, stdout, stderr) {
+            exec('node lib/index.js validate testData/invalid/yaml/invalid_yaml.yaml', function(error, stdout, stderr) {
                 expect(error).to.have.property('code', 1);
-                expect(stdout).to.contain('Unable to parse template!');
+                expect(stdout).to.contain('Unable to parse template! Use --verbose for more information.');
+                expect(stderr).to.be.empty;
                 done();
             });
         }).timeout(5000);
 
         it('handle validation exceptions - verbose', (done) => {
-            exec('node lib/index.js validate testData/invalid/some_file_that_does_not_exist --verbose', function(error, stdout, stderr) {
+            exec('node lib/index.js validate testData/invalid/yaml/invalid_yaml.yaml --verbose', function(error, stdout, stderr) {
                 expect(error).to.have.property('code', 1);
-                expect(stdout).to.contain('Unable to parse template!');
-                expect(stderr).to.contain('Could not find file');
+                expect(stdout).to.contain('Unable to parse template! Use --verbose for more information.');
+                expect(stderr).to.contain('Error: Could not determine file type');
                 done();
             });
         }).timeout(5000);

--- a/src/test/indexTest.ts
+++ b/src/test/indexTest.ts
@@ -100,6 +100,23 @@ describe('index', () => {
                 done();
             });
         }).timeout(5000);
+
+        it('handle validation exceptions - non-verbose', (done) => {
+            exec('node lib/index.js validate testData/invalid/some_file_that_does_not_exist', function(error, stdout, stderr) {
+                expect(error).to.have.property('code', 1);
+                expect(stdout).to.contain('Unable to parse template!');
+                done();
+            });
+        }).timeout(5000);
+
+        it('handle validation exceptions - verbose', (done) => {
+            exec('node lib/index.js validate testData/invalid/some_file_that_does_not_exist --verbose', function(error, stdout, stderr) {
+                expect(error).to.have.property('code', 1);
+                expect(stdout).to.contain('Unable to parse template!');
+                expect(stderr).to.contain('Could not find file');
+                done();
+            });
+        }).timeout(5000);
     });
 
 });


### PR DESCRIPTION
Fixed #121 and #122. Catches exceptions thrown in template validation and logs `Unable to parse template!` to `stdout`, if `--verbose` flag provided then logs the exception to `stderr`. In both cases the exit code is `1`.