### PR TITLE
Replaced imperfect "safer-buffer" polyfill.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Fixed
 - Merge PR #120, fixing dependency issue with "@types/colors"
-- Merge PR #127, implementing "safer-buffer" polyfill to be compatible with older NodeJS versions
+- Merge PR #130, implementing "safe-buffer" polyfill to be compatible with older NodeJS versions
 - Merge PR #126, improving null value validation when null is passed into a template
 
 ## [1.5.1] - 2018-03-12

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "js-yaml": "^3.7.0",
     "opn": "^5.2.0",
     "winston": "^2.4.0",
-    "source-map-support": "^0.5.0"
+    "source-map-support": "^0.5.0",
+    "safer-buffer": "^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "opn": "^5.2.0",
     "winston": "^2.4.0",
     "source-map-support": "^0.5.0",
-    "safer-buffer": "^2.1.0"
+    "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/src/util/polyfills.ts
+++ b/src/util/polyfills.ts
@@ -1,4 +1,4 @@
 require('core-js/fn/string/raw');
 require('core-js/fn/object/assign');
 require('core-js/fn/array/entries');
-Buffer = require('safer-buffer').Buffer;
+Buffer = require('safe-buffer').Buffer;

--- a/src/util/polyfills.ts
+++ b/src/util/polyfills.ts
@@ -1,3 +1,4 @@
 require('core-js/fn/string/raw');
 require('core-js/fn/object/assign');
 require('core-js/fn/array/entries');
+Buffer = require('safer-buffer').Buffer;


### PR DESCRIPTION
Apparently, the current polyfill did not provide a constructor function and therefore `instanceof` failed; I've also noticed a few dissimilarities with the Buffer API.