### PR TITLE
Issue #145 - CircleCI build failling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: cleanup-global-node_modules
+          command: 'sudo npm config set prefix /tmp'
+      - run:
           name: update-npm
           command: 'sudo npm install -g npm@latest'
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     working_directory: ~/cfn-lint
     docker:
-      - image: circleci/node:4.8.2
+      - image: circleci/node:boron-stretch
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Merge PR #136, updated usage prompt for a better CLI experience
+- Merge PR #146, updated build environment to circleci/node:boron-stretch to support npm v6.0.0
 
 ## [1.6.0] - 2018-04-05
 ### Fixed


### PR DESCRIPTION
Updated the *CircleCI* docker image to use *NodeJS Boron* running on *Debian Stretch* and ensured that the global `node_modules` directory is in a pristine state.