### PR TITLE
Implement Fn::Split, remove cloudformation-js-yaml-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Merge PR #157, adding licence attribute to package.json
+- Merge PR #148, removing cloudformation-js-yaml-schema in favour of custom handling of intrinsic functions
+
+### Added
+- Merge PR #148, adding Fn::split functionality
 
 
 ## [1.6.2] - 2018-04-26

--- a/data/aws_intrinsic_functions.json
+++ b/data/aws_intrinsic_functions.json
@@ -13,7 +13,7 @@
   "Fn::Select": {},
   "Fn::Select::Index": {"supportedFunctions": ["Ref", "Fn::FindInMap"]},
   "Fn::Select::List": {"supportedFunctions" : ["Fn::FindInMap", "Fn::GetAtt", "Fn::GetAZs", "Fn::If", "Fn::Split", "Ref"] },
-  "Fn::Split": {},
+  "Fn::Split": {"supportedFunctions": ["Fn::Base64", "Fn::FindInMap", "Fn::GetAtt", "Fn::If", "Fn::Join", "Fn::Select", "Ref"]},
   "Fn::Sub": { "supportedFunctions": ["Fn::Base64", "Fn::FindInMap", "Fn::GetAtt", "Fn::GetAZs", "Fn::If", "Fn::Join", "Fn::Select", "Ref"]},
   "Ref": {}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/martysweet/cfn-lint/issues"
   },
   "dependencies": {
-    "cloudformation-js-yaml-schema": "0.3.0",
     "colors": "^1.2.1",
     "commander": "^2.15.0",
     "core-js": "^2.5.1",

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -526,6 +526,97 @@ describe('validator', () => {
 
     });
 
+    describe('Fn::Split', () => {
+        it('should split a basic string', () => {
+            const input = {
+                'Fn::Split': ['-', 'asdf-fdsa']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['asdf', 'fdsa']);
+        });
+
+        it('should split a string that doesn\'t contain the delimiter', () => {
+            const input = {
+                'Fn::Split': ['-', 'asdffdsa']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['asdffdsa']);
+        });
+
+        it('should resolve an intrinsic function', () => {
+            const input = {
+                'Fn::Split': ['-', {
+                    'Fn::Select': [1, ['0-0', '1-1', '2-2']]
+                }]
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['1', '1']);
+        });
+
+        it('should reject a parameter that is an object', () => {
+            const input = {
+                'Fn::Split': {}
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is a string', () => {
+            const input = {
+                'Fn::Split': 'split-me-plz'
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is an empty array', () => {
+            const input = {
+                'Fn::Split': []
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is a single length array', () => {
+            const input = {
+                'Fn::Split': ['delim']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a delimiter that isn\'t a string', () => {
+            const input = {
+                'Fn::Split': [{}, 'asd-asd-asd']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        describe('validator test', () => {
+            let result: validator.ErrorObject;
+            before(() => {
+                validator.resetValidator();
+                const input = './testData/valid/yaml/split.yaml';
+                result = validator.validateFile(input);
+            });
+            it('should have no errors', () => {
+                console.dir(result['errors']);
+                expect(result).to.have.deep.property('templateValid', true);
+                expect(result['errors']['crit']).to.have.lengthOf(0);
+            });
+            it('should resolve a simple split', () => {
+                expect(result['outputs']['Simple']).to.deep.equal(['asdf', 'fdsa']);
+            });
+            it('should resolve a split of a join', () => {
+                expect(result['outputs']['Nested']).to.deep.equal(['asdf', 'fdsa_asdf', 'fdsa']);
+            });
+            it('should resolve a select of a split', () => {
+                expect(result['outputs']['SelectASplit']).to.deep.equal('b');
+            });
+        });
+    })
+
     describe('templateVersion', () => {
 
         it('1 invalid template version should return an object with validTemplate = false, 1 crit errors', () => {

--- a/src/test/yamlSchema.ts
+++ b/src/test/yamlSchema.ts
@@ -1,0 +1,38 @@
+import buildYamlSchema, * as yamlSchema from '../yamlSchema';
+import yaml = require('js-yaml');
+import assert = require('assert');
+
+describe('yamlSchema', () => {
+    describe('buildYamlSchema', () => {
+        it('should build a yaml schema', () => {
+            assert(buildYamlSchema() instanceof yaml.Schema, 'yamlSchema didn\'t return a yaml schema');
+        })
+    });
+
+    describe('functionTag', () => {
+        it('should work on a Fn::Thing', () => {
+            assert.strictEqual(yamlSchema.functionTag('Fn::Name'), 'Name');
+        })
+        it('should work on a Thing', () => {
+            assert.strictEqual(yamlSchema.functionTag('Name'), 'Name');
+        })
+    });
+
+    describe('buildYamlType', () => {
+        it('should return a type that builds the JSON representation of the yaml tag', () => {
+            const type = yamlSchema.buildYamlType('Fn::Join', 'sequence');
+            const input = ['asdf', 'asdf'];
+            const representation = type.construct(input);
+            assert.deepStrictEqual(representation, {'Fn::Join': ['asdf', 'asdf']});
+        });
+
+        it('should special-case Fn::GetAtt', () => {
+            const type = yamlSchema.buildYamlType('Fn::GetAtt', 'scalar');
+            const input = 'Resource.Attribute';
+            const representation = type.construct(input);
+            assert.deepStrictEqual(representation, {'Fn::GetAtt': ['Resource', 'Attribute']});
+        })
+    })
+
+
+})

--- a/src/yamlSchema.ts
+++ b/src/yamlSchema.ts
@@ -1,0 +1,36 @@
+import yaml = require('js-yaml');
+
+export function functionTag(functionName: string) {
+    const splitFunctionName = functionName.split('::');
+    return splitFunctionName[splitFunctionName.length-1];
+}
+
+export default function buildYamlSchema() {
+    const intrinsicFunctions = require('../data/aws_intrinsic_functions.json');
+    const yamlTypes = [];
+    for (const fn in intrinsicFunctions) {
+        yamlTypes.push(...buildYamlTypes(fn));
+    }
+    return yaml.Schema.create(yamlTypes);
+}
+
+export type YamlKind = 'scalar' | 'mapping' | 'sequence';
+const kinds: YamlKind[] = ['scalar', 'mapping', 'sequence'];
+
+export function buildYamlTypes(fnName: string) {
+    return kinds.map((kind) => buildYamlType(fnName, kind));
+}
+
+export function buildYamlType(fnName: string, kind: YamlKind) {
+    const tagName = functionTag(fnName);
+    const tag = `!${tagName}`;
+
+    const constructFn = (fnName === 'Fn::GetAtt')
+        ? (data: any) => ({'Fn::GetAtt': data.split('.')})
+        : (data: any) => ({[fnName]: data});
+
+    return new yaml.Type(tag, {
+        kind,
+        construct: constructFn
+    });
+}

--- a/testData/valid/yaml/split.yaml
+++ b/testData/valid/yaml/split.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Resources:
+  WebServerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Desc
+      SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: '80'
+        IpProtocol: tcp
+        ToPort: '80'
+
+Outputs:
+  Simple:
+    Value: !Split ['-', 'asdf-fdsa']
+  Nested:
+    Value: !Split ['^', !Join ['_', [asdf^fdsa, asdf^fdsa]]]
+  SelectASplit:
+    Value: !Select
+      - 1,
+      - !Split ['@', 'a@b@c']


### PR DESCRIPTION
This PR implements and tests Fn::Split.

I couldn't do this to begin with as cloudformation-js-yaml-schema does not have a working version available. The current dependency 0.3.1 does not recognize !Split, and the latest version 0.3.4 does not recognize !ImportValue when its argument is a string.

Looking through the source of cloudformation-js-yaml-schema, I believe it will cause yaml parse errors on other inputs as well which might be the source of other bugs. It assumes that arguments to !Tags are a certain type (string, array, obj), and throws a parse error if the type doesn't match. We should be (and generally are) doing that check ourself so we can give better feedback to the user - we should be saying "You can't pass a string to Fn::Join", not "Yaml parse error".

However, we can do everything it does easily using the spec files we already have at our disposal. This also significantly cleans up parser.ts as a result, yay!