### PR TITLE
WIP: Refactor intrinsics

### DIFF
--- a/data/aws_intrinsic_functions.json
+++ b/data/aws_intrinsic_functions.json
@@ -13,7 +13,7 @@
   "Fn::Select": {},
   "Fn::Select::Index": {"supportedFunctions": ["Ref", "Fn::FindInMap"]},
   "Fn::Select::List": {"supportedFunctions" : ["Fn::FindInMap", "Fn::GetAtt", "Fn::GetAZs", "Fn::If", "Fn::Split", "Ref"] },
-  "Fn::Split": {},
+  "Fn::Split": {"supportedFunctions": ["Fn::Base64", "Fn::FindInMap", "Fn::GetAtt", "Fn::If", "Fn::Join", "Fn::Select", "Ref"]},
   "Fn::Sub": { "supportedFunctions": ["Fn::Base64", "Fn::FindInMap", "Fn::GetAtt", "Fn::GetAZs", "Fn::If", "Fn::Join", "Fn::Select", "Ref"]},
   "Ref": {}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/martysweet/cfn-lint/issues"
   },
   "dependencies": {
-    "cloudformation-js-yaml-schema": "0.3.0",
     "colors": "^1.2.1",
     "commander": "^2.15.0",
     "core-js": "^2.5.1",

--- a/src/awsData.ts
+++ b/src/awsData.ts
@@ -62,7 +62,7 @@ export type Property = PrimitiveProperty | ComplexProperty | ListProperty | MapP
 export interface ResourcePropertyType {
     Documentation: string,
     Properties: {[propertyName: string]: Property | undefined}
-    
+
     AdditionalProperties: undefined;
 }
 
@@ -101,16 +101,11 @@ export const awsParameterTypes = require('../data/aws_parameter_types.json') as 
 
 type IntrinsicFunctions = {
     [functionName: string]: {
-        supportedFunctions: string[]
+        supportedFunctions?: string[]
     }
 }
 
 export const awsIntrinsicFunctions = require('../data/aws_intrinsic_functions.json') as IntrinsicFunctions;
-
-// avoid "does this exist" checks everywhere
-for (let functionName in awsIntrinsicFunctions) {
-    awsIntrinsicFunctions[functionName].supportedFunctions = awsIntrinsicFunctions[functionName].supportedFunctions || [];
-}
 
 type RefOverrides = {
     "AWS::AccountId": string,
@@ -123,4 +118,5 @@ type RefOverrides = {
 };
 
 export const awsRefOverrides = require('../data/aws_ref_override.json') as RefOverrides;
+
 awsRefOverrides["AWS::NoValue"] = undefined;

--- a/src/intrinsics.ts
+++ b/src/intrinsics.ts
@@ -1,0 +1,483 @@
+import {getRef, fnGetAtt, fnFindInMap, isInteger, isString, BreadcrumbTrail} from './validator';
+import util = require('util');
+import objectMap = require('./util/objectMap');
+import isObject = require('./util/isObject');
+import { awsIntrinsicFunctions } from './awsData';
+import CustomError = require('./util/CustomError');
+
+const intrinsics: {[k: string]: Intrinsic<any, any>} = {};
+
+export class IntrinsicError extends CustomError {
+    boundIntrinsic: BoundIntrinsic<any, any>
+    constructor(boundIntrinsic: BoundIntrinsic<any, any>, message: string) {
+        super(message);
+        this.boundIntrinsic = boundIntrinsic;
+
+        CustomError.fixErrorInheritance(this, IntrinsicError)
+    }
+}
+
+export class NoSuchIntrinsic extends CustomError {
+    constructor() { super('No such intrinsic!') }
+};
+
+export type Resolveable<T> = T | BoundIntrinsic<any, T>;
+
+export function _buildIntrinsic(fnName: string, arg: any, placeInTemplate: BreadcrumbTrail, workingInput: any) {
+    if (!(fnName in intrinsics)) {
+        throw new NoSuchIntrinsic();
+    }
+
+    return intrinsics[fnName].bind(arg, placeInTemplate, workingInput);
+}
+
+/*
+export interface BoundIntrinsic<T> extends Intrinsic<any, T> {
+    (): T;
+    fnName: string
+}
+*/
+
+function checkFunctionIsAllowed(fnName: string, containingFunction?: BoundIntrinsic<any, any>) {
+    if (!containingFunction) { return true; }
+    const supportedFunctions = awsIntrinsicFunctions[containingFunction.fnName].supportedFunctions;
+    if (!supportedFunctions) { return true; }
+
+    if (supportedFunctions.indexOf(fnName) >= 0) { return true; }
+
+    throw new IntrinsicError(containingFunction, `${containingFunction.fnName} cannot contain ${fnName}. It can only contain ${supportedFunctions.join(',')}`);
+}
+
+function _resolve<T>(value: Resolveable<T>, containingFunction?: BoundIntrinsic<any, any>): T {
+    if (value instanceof BoundIntrinsic) {
+        checkFunctionIsAllowed(value.fnName, containingFunction);
+        return value.call();
+    }
+    return value;
+}
+
+export function recursiveResolve<T>(value: Resolveable<T>, containingFunction?: BoundIntrinsic<any, any>): T {
+    const primitiveOrContainer = _resolve(value, containingFunction);
+    if (Array.isArray(primitiveOrContainer)) {
+        return primitiveOrContainer.map(
+            (e) => _resolve(e, containingFunction)
+        ) as any as T;
+    } else if (isObject(primitiveOrContainer)) {
+        return objectMap(primitiveOrContainer,
+            (e) => _resolve(e, containingFunction)
+        ) as any as T;
+    } else {
+        return primitiveOrContainer;
+    }
+}
+
+export type IntrinsicFunction<A, T> = (this: BoundIntrinsic<A, T>, arg: A, workingInput: any) => T;
+
+export class Intrinsic<A, T> {
+    private f: IntrinsicFunction<A, T>;
+    fnName: string;
+
+    constructor(fnName: string, f: IntrinsicFunction<A, T>) {
+        this.f = f;
+        this.fnName = fnName;
+        intrinsics[fnName] = this;
+    }
+
+    bind(args: A, placeInTemplate: BreadcrumbTrail, workingInput: any): BoundIntrinsic<A, T> {
+        return new BoundIntrinsic(this, this.f, args, placeInTemplate, workingInput);
+    }
+
+    test(args: any) {
+        return this.bind(args, [], {}).call();
+    }
+}
+
+export class BoundIntrinsic<A, T> {
+    fnName: string;
+    private f: () => T;
+    placeInTemplate: BreadcrumbTrail;
+    called: boolean;
+    workingInput: any;
+
+    constructor(
+        intrinsic: Intrinsic<A, T>,
+        f: IntrinsicFunction<A, T>,
+        args: A,
+        placeInTemplate: BreadcrumbTrail,
+        workingInput: any
+    ) {
+        this.fnName = intrinsic.fnName;
+        this.f = f.bind(this, args);
+        this.placeInTemplate = placeInTemplate;
+        this.called = false;
+        this.workingInput = workingInput;
+        Object.defineProperty(f, 'name', {value: this.fnName});
+    }
+
+    IntrinsicError(message: string) {
+        return new IntrinsicError(this, message);
+    }
+
+    resolve<R>(value: Resolveable<R>) {
+        return recursiveResolve(value, this);
+    }
+
+    call() {
+        this.called = true;
+        return this.f();
+    }
+}
+
+/*
+function Intrinsic<A, T> (fnName: string, f: (this: Intrinsic<A, T>, arg: A) => T): Intrinsic<A, T>  {
+    const builder = (arg: A) => BoundIntrinsic(fnName, f, arg);
+    const intrinsic: Intrinsic<A, T> = Object.setPrototypeOf(builder, Intrinsic.prototype);
+    intrinsic.fnName = fnName;
+    intrinsic.constructor = Intrinsic;
+
+    intrinsics[fnName] = intrinsic;
+    return intrinsic;
+}
+Intrinsic.prototype = Object.create(Function.prototype, {
+    resolve: {
+        value: function<T> (r: Resolveable<T>) {
+            return resolve(r);
+        }
+    },
+    IntrinsicError: {
+        value: function (msg: string) { return new IntrinsicError(this.fnName, msg) }
+    }
+});
+*/
+
+/*
+export function BoundIntrinsic<A, T>(fnName: string, f: (a: A) => T, arg: A): BoundIntrinsic<T> {
+    const boundF = Object.setPrototypeOf(f.bind(f, arg), BoundIntrinsic.prototype);
+    return Object.assign(boundF, {fnName});
+}
+BoundIntrinsic.prototype = Object.create(Intrinsic.prototype);
+*/
+/*
+export interface Intrinsic<A, T> {
+    (a: A): BoundIntrinsic<T>;
+    resolve: <R>(r: Resolveable<R>) => R;
+    IntrinsicError: (s: string) => IntrinsicError;
+    fnName: string
+}
+*/
+
+/*class Intrinsic<A, T> {
+
+    constructor(f: (this: Intrinsic<A, T>, arg: A) => T): (arg: A) => BoundIntrinsic<T>  {
+        const boundF = (arg: A) => f.bind(null, arg);
+        Object.setPrototypeOf(boundF, Intrinsic);
+    }
+
+    bind(arg: A) {
+        this.arg = arg;
+    }
+
+    resolve<T>(r: Resolveable<T>) {
+        return resolve(r);
+    }
+}
+*/
+
+export const Ref = new Intrinsic('Ref', function (reference: string) {
+    // Check if the value of the Ref exists
+    const resolvedVal = getRef(reference);
+    if (resolvedVal === null) {
+        throw this.IntrinsicError(`Referenced value ${reference} does not exist`)
+    }
+    return resolvedVal;
+});
+
+export const Base64 = new Intrinsic('Fn::Base64', function (value: Resolveable<string>) {
+    const resolved = this.resolve(value);
+
+    if (typeof resolved !== "string"){
+        throw this.IntrinsicError('Parameter of Fn::Base64 is not a string');
+    }
+
+    return Buffer.from(resolved).toString('base64');
+})
+
+export const Join = new Intrinsic('Fn::Join', function (args: [string, Resolveable<string>[]]) {
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw this.IntrinsicError('Invalid parameters for Fn::Join. It needs [string, string[]].');
+    }
+
+    const joiner = args[0];
+    if (typeof joiner !== 'string') {
+        throw this.IntrinsicError('Fn::Join needs its delimiter to be, or resolve to, a string.');
+    }
+
+    const parts = args[1];
+    if (!Array.isArray(parts)) {
+        throw this.IntrinsicError('Fn::Join needs its second parameter to be a list of values.');
+    }
+
+    const resolvedParts = this.resolve(parts);
+    let naughty: any;
+    if (naughty = resolvedParts.find((p) => !isString(p))) {
+        throw this.IntrinsicError(`Fn::Join can only join strings. You provided ${naughty}.`);
+    }
+
+    return parts.join(joiner);
+
+});
+
+export const GetAtt = new Intrinsic('Fn::GetAtt', function (args: [string, Resolveable<string>]) {
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw this.IntrinsicError('Invalid parameters for Fn::GetAtt');
+    }
+
+    const reference = args[0];
+    if (typeof reference !== 'string') {
+        throw this.IntrinsicError('Fn::GetAtt does not support functions for the logical resource name');
+    }
+
+    const attributeName = this.resolve(args[1]);
+    if (typeof attributeName !== 'string') {
+        throw this.IntrinsicError('Fn::GetAtt needs a string for the attribute to get.');
+    }
+
+    const resolved = fnGetAtt(reference, attributeName);
+
+    if (resolved === null) {
+        throw this.IntrinsicError(`Invalid GetAtt - ${reference}.${attributeName}`);
+    }
+
+    return resolved;
+});
+
+export const FindInMap = new Intrinsic('Fn::FindInMap', function (args: Resolveable<string>[]) {
+
+    if (!Array.isArray(args) || args.length !== 3) {
+        throw this.IntrinsicError('Invalid parameters for Fn::FindInMap');
+    }
+
+    const toGet = args.map((arg) => this.resolve(arg));
+
+    if (toGet.findIndex((r) => (typeof r !== 'string')) > -1) {
+        throw this.IntrinsicError('Invalid parameter for Fn::FindInMap. It needs a string.');
+    }
+
+    const value = fnFindInMap(toGet[0], toGet[1], toGet[2]);
+    if (value == null) {
+        throw this.IntrinsicError(`Could not find value in map ${toGet[0]}|${toGet[1]}|${toGet[2]}. Have you tried specifying input parameters?`);
+    }
+
+    return value;
+
+})
+
+export const GetAZs = new Intrinsic('Fn::GetAZs', function (arg: Resolveable<string>) {
+    const region = this.resolve(arg);
+
+    if (typeof region !== 'string') {
+        throw this.IntrinsicError('Fn::GetAZs only supports Ref or string as a parameter');
+    }
+
+    // TODO
+    // if(toGet[key] != 'AWS::Region'){
+    //     addError("warn", "Fn::GetAZs expects a region, ensure this reference returns a region", placeInTemplate, "Fn::GetAZs");
+    // }
+
+    const AZs = ['a', 'b', 'c'].map((s) => `${region}${s}`);
+    return AZs;
+})
+
+export const Select = new Intrinsic('Fn::Select', function (arg: [Resolveable<string|number>, Resolveable<any[]>]) {
+    if (!Array.isArray(arg) || arg.length !== 2) {
+        throw this.IntrinsicError('Fn::Select only supports an array ot two elements');
+    }
+
+    const indexStr = this.resolve(arg[0]);
+    if (!isInteger(indexStr)) {
+        throw this.IntrinsicError("Fn::Select's first argument did not resolve to a string for parsing or a numeric value.");
+    }
+
+    const index = parseInt(indexStr as string);
+
+    const list = this.resolve(arg[1]);
+    if (!Array.isArray(list)) {
+        throw this.IntrinsicError(`Fn::Select requires the second element to be a list, function call did not resolve to a list. It contains value ${list}`);
+    }
+
+    if (index < 0 || index >= list.length) {
+        throw this.IntrinsicError("First element of Fn::Select exceeds the length of the list.");
+    }
+
+    return list[index] as any;
+}) as Intrinsic<[Resolveable<string|number>, Resolveable<any>], any>
+
+function getSubArgs(_this: BoundIntrinsic<any, any>, arg: string | [string, {[k: string]: any}]): [string, {[k: string]: any}] {
+
+    if (typeof arg === 'string') {
+        return [arg, {}];
+    } else if (Array.isArray(arg) && arg.length === 2) {
+
+        const replacementString = arg[0];
+        if (typeof replacementString !== 'string') {
+            throw _this.IntrinsicError('Fn::Sub expects first argument to be a string');
+        }
+
+        const mapping = _this.resolve(arg[1]);
+        if (typeof mapping !== 'object') {
+            throw _this.IntrinsicError('Fn::Sub expects second argument to be a variable map');
+        }
+
+        const vars = objectMap(mapping, (v) => _this.resolve(v));
+
+        return [replacementString, vars];
+
+    } else {
+        throw _this.IntrinsicError('Fn::Sub needs a string or an array of length 2.');
+    }
+
+}
+
+export const Sub = new Intrinsic('Fn::Sub', function (arg: string | [string, {[k: string]: any}]) {
+
+    const [replacementString, vars] = getSubArgs(this, arg);
+
+    const regex = /\${([A-Za-z0-9:.!]+)/gm;
+
+        return replacementString.replace(regex, (_: string, subMatch: string) => {
+            if (subMatch.indexOf('!') === 1) {
+                return subMatch;
+            } else if (subMatch in vars) {
+                return vars[subMatch];
+            } else if (subMatch.indexOf('.') !== -1) {
+                const [resource, ...attributes] = subMatch.split('.');
+                const joinedAttribute = attributes.join('.');
+                const resolved = fnGetAtt(resource, joinedAttribute);
+                if (resolved == null) {
+                    throw this.IntrinsicError(`Intrinsic Sub does not reference valid resource attribute '${subMatch}'`);
+                }
+                return resolved;
+            } else {
+                const resolved = getRef(subMatch);
+                if (resolved == null) {
+                    throw this.IntrinsicError(`Intrinsic Sub does not reference valid resource or mapping '${subMatch}'`);
+                }
+                return resolved;
+            }
+        });
+
+})
+
+export const If = new Intrinsic('Fn::If', function (arg: [string, Resolveable<any>, Resolveable<any>]) {
+    if (!Array.isArray(arg) || arg.length !== 3) {
+        throw this.IntrinsicError(`Fn::If must be an array with 3 arguments.`);
+    }
+
+    const ifTrue = arg[1];
+    const ifFalse = arg[2];
+    const condition = implicitCondition(arg[0], this.placeInTemplate, this.workingInput);
+    const conditionValue = this.resolve(condition);
+
+    if (conditionValue) {
+        return this.resolve(ifTrue);
+    } else {
+        return this.resolve(ifFalse);
+    }
+})
+
+export const Equals = new Intrinsic('Fn::Equals', function (arg: [Resolveable<any>, Resolveable<any>]) {
+    if (!Array.isArray(arg) || arg.length !== 2) {
+        throw this.IntrinsicError('Fn::Equals expects an array with 2 arguments.');
+    }
+
+    const v1 = this.resolve(arg[0]);
+    const v2 = this.resolve(arg[1]);
+
+    return (v1 == v2);
+})
+
+export const Or = new Intrinsic('Fn::Or', function (arg: any[]) {
+    if (!Array.isArray(arg) || arg.length < 2 || arg.length > 10) {
+        throw this.IntrinsicError('Fn::Or wants an array of between 2 and 10 arguments');
+    }
+
+    return Boolean(arg.find((condition) => this.resolve(condition) === true));
+});
+
+export const Not = new Intrinsic('Fn::Not', function (arg: [Resolveable<boolean>]) {
+    if (!Array.isArray(arg) || arg.length !== 1) {
+        throw this.IntrinsicError('Fn::Not expects an array of length 1');
+    }
+
+    const condition = this.resolve(arg[0]);
+
+    if (typeof condition !== 'boolean') {
+        throw this.IntrinsicError(`Fn::Not did not resolve to a boolean value, ${util.inspect(condition)} given`);
+    }
+
+    return !condition;
+})
+
+export const ImportValue = new Intrinsic('Fn::ImportValue', function (arg: Resolveable<string>) {
+    const importName = this.resolve(arg);
+    if (importName !== 'string') {
+        throw this.IntrinsicError('Something went wrong when resolving references for a Fn::ImportValue');
+    }
+
+    return `IMPORTEDVALUE${importName}`;
+});
+
+export const Split = new Intrinsic('Fn::Split', function (args: [string, Resolveable<string>]) {
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw this.IntrinsicError('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+    }
+
+    const delimiter = args[0];
+    if (typeof delimiter !== 'string') {
+        throw this.IntrinsicError(`Invalid parameter for Fn::Split. The delimiter, ${util.inspect(delimiter)}, needs to be a string.`);
+    }
+
+    const stringToSplit = this.resolve(args[1]);
+    if (typeof stringToSplit !== 'string') {
+        throw this.IntrinsicError(`Invalid parameters for Fn::Split. The parameter, ${stringToSplit}, needs to be a string or a supported intrinsic function.`);
+    }
+
+    return stringToSplit.split(delimiter);
+
+});
+
+export const Condition = new Intrinsic('Condition', function (arg: string, workingInput: any) {
+    if (typeof arg !== 'string') {
+        throw this.IntrinsicError('Invalid parameter for Condition. It needs a string.');
+    }
+
+    return resolveCondition(this, arg, workingInput);
+});
+
+function implicitCondition(conditionName: string, placeInTemplate: BreadcrumbTrail, workingInput: any) {
+    return Condition.bind(conditionName, placeInTemplate, workingInput);
+}
+
+function resolveCondition(_this: BoundIntrinsic<any, any>, conditionName: string, workingInput: any) {
+
+    if (!workingInput.Conditions || !workingInput.Conditions[conditionName]) {
+        throw _this.IntrinsicError(`Condition ${conditionName} must reference a valid condition.`);
+    }
+
+    const condition = workingInput.Conditions[conditionName];
+
+    // TODO: containing function
+    const resolvedCondition = recursiveResolve(condition, undefined)
+
+    if (typeof resolvedCondition !== 'boolean') {
+        throw _this.IntrinsicError(`Condition ${conditionName} returned ${resolveCondition}, it should have returned a boolean.`);
+    }
+
+    return resolvedCondition;
+}
+
+export const UnhandledIntrinsic = new Intrinsic('X::UnhandledIntrinsic', function (arg: any) {
+    return 'UNHANDLED_INTRINSIC';
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,10 +4,11 @@ let logger = new (winston.Logger)({
     transports: [
         new (winston.transports.Console)({ json: false, timestamp: true, level: 'debug' }),
     ],
-    exceptionHandlers: [
+    /*exceptionHandlers: [
         new (winston.transports.Console)({ json: false, timestamp: true }),
     ],
     exitOnError: true
+    */
 });
 
 export = logger;

--- a/src/test/intrinsics.ts
+++ b/src/test/intrinsics.ts
@@ -1,0 +1,131 @@
+import * as intrinsics from '../intrinsics';
+import {expect} from 'chai';
+
+describe('Intrinsics', () => {
+    const {Intrinsic, BoundIntrinsic} = intrinsics;
+    describe('Intrinsic class', () => {
+        it('should be able to be constructed', () => {
+            const TestIntrinsic = new Intrinsic('test', function (a: any) {
+                return 'result';
+            });
+        });
+
+        it('bind() and call() should work together', () => {
+            const TestIntrinsic = new Intrinsic('test', function (a: any) {
+                return a;
+            });
+
+            const arg = {};
+            const boundIntrinsic = TestIntrinsic.bind(arg, [], {});
+            expect(boundIntrinsic.call()).to.equal(arg);
+        });
+
+        describe('bind()', () => {
+            it('should return something with a call method', () => {
+
+                const TestIntrinsic = new Intrinsic('test', function (a: any) {
+                    return a;
+                });
+
+                const result = TestIntrinsic.bind(undefined, [], {});
+
+                expect(result).to.have.property('call');
+            });
+
+            it('should return something that is instanceof BoundIntrinsic', () => {
+
+                const TestIntrinsic = new Intrinsic('test', function (a: any) {
+                    return a;
+                });
+
+                const result = TestIntrinsic.bind(undefined, [], {});
+
+                expect(result).to.be.instanceOf(BoundIntrinsic);
+            })
+        });
+    })
+
+    describe.only('Fn::Join', () => {
+        const Join = intrinsics.Join;
+
+        it('should join a basic array', () => {
+            const result = Join.test(['-', ['asdf', 'fdsa']]);
+            expect(result).to.deep.equal('asdf-fdsa');
+        });
+
+        it('should join with an empty delimiter', () => {
+            const result = Join.test(['', ['asdf', 'fdsa']]);
+            expect(result).to.deep.equal('asdffdsa');
+        });
+
+        it('should fail if the second parameter is a string', () => {
+            expect(() =>
+                Join.test(['', 'asdffdsa'])
+            ).to.throw('Fn::Join needs its second parameter to be a list of values.');
+        });
+
+        it('should fail if it receives a longer list than 2', () => {
+            expect(() =>
+                Join.test(['', 'asdffdsa', 'asdf'])
+            ).to.throw('Invalid parameters for Fn::Join. It needs [string, string[]].');
+        });
+
+    })
+
+    describe('Fn::Split', () => {
+        const Split = intrinsics.Split;
+
+        it('should split a basic string', () => {
+            const result = Split.test(['-', 'asdf-fdsa'])
+            expect(result).to.deep.equal(['asdf', 'fdsa']);
+        });
+
+        it('should split a string that doesn\'t contain the delimiter', () => {
+            const result = Split.test(['-', 'asdffdsa'])
+            expect(result).to.deep.equal(['asdffdsa']);
+        });
+
+        it('should resolve an intrinsic function', () => {
+            const Select = intrinsics.Select;
+
+            const result = Split.test([
+                '-',
+                Select.bind([
+                    1,
+                    ['0-0', '1-1', '2-2']
+                ], [], {})
+            ])
+            expect(result).to.deep.equal(['1', '1']);
+        });
+
+        it('should reject a parameter that is an object', () => {
+            expect(() =>
+                Split.test([{}])
+            ).to.throw('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+        });
+
+        it('should reject a parameter that is a string', () => {
+            expect(() =>
+                Split.test('split-me-plz')
+            ).to.throw('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+        });
+
+        it('should reject a parameter that is an empty array', () => {
+            expect(() =>
+                Split.test([])
+            ).to.throw('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+        });
+
+        it('should reject a parameter that is a single length array', () => {
+            expect(() =>
+                Split.test(['delim'])
+            ).to.throw('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+        });
+
+        it('should reject a delimiter that isn\'t a string', () => {
+            expect(() =>
+                Split.test([{}, 'asd-asd-asd'])
+            ).to.throw('Invalid parameter for Fn::Split. The delimiter, {}, needs to be a string.');
+        });
+    })
+})

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -526,6 +526,97 @@ describe('validator', () => {
 
     });
 
+    describe('Fn::Split', () => {
+        it('should split a basic string', () => {
+            const input = {
+                'Fn::Split': ['-', 'asdf-fdsa']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['asdf', 'fdsa']);
+        });
+
+        it('should split a string that doesn\'t contain the delimiter', () => {
+            const input = {
+                'Fn::Split': ['-', 'asdffdsa']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['asdffdsa']);
+        });
+
+        it('should resolve an intrinsic function', () => {
+            const input = {
+                'Fn::Split': ['-', {
+                    'Fn::Select': [1, ['0-0', '1-1', '2-2']]
+                }]
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['1', '1']);
+        });
+
+        it('should reject a parameter that is an object', () => {
+            const input = {
+                'Fn::Split': {}
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is a string', () => {
+            const input = {
+                'Fn::Split': 'split-me-plz'
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is an empty array', () => {
+            const input = {
+                'Fn::Split': []
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a parameter that is a single length array', () => {
+            const input = {
+                'Fn::Split': ['delim']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        it('should reject a delimiter that isn\'t a string', () => {
+            const input = {
+                'Fn::Split': [{}, 'asd-asd-asd']
+            };
+            const result = validator.doInstrinsicSplit(input, 'Fn::Split');
+            expect(result).to.deep.equal(['INVALID_SPLIT']);
+        });
+
+        describe('validator test', () => {
+            let result: validator.ErrorObject;
+            before(() => {
+                validator.resetValidator();
+                const input = './testData/valid/yaml/split.yaml';
+                result = validator.validateFile(input);
+            });
+            it('should have no errors', () => {
+                console.dir(result['errors']);
+                expect(result).to.have.deep.property('templateValid', true);
+                expect(result['errors']['crit']).to.have.lengthOf(0);
+            });
+            it('should resolve a simple split', () => {
+                expect(result['outputs']['Simple']).to.deep.equal(['asdf', 'fdsa']);
+            });
+            it('should resolve a split of a join', () => {
+                expect(result['outputs']['Nested']).to.deep.equal(['asdf', 'fdsa_asdf', 'fdsa']);
+            });
+            it('should resolve a select of a split', () => {
+                expect(result['outputs']['SelectASplit']).to.deep.equal('b');
+            });
+        });
+    })
+
     describe('templateVersion', () => {
 
         it('1 invalid template version should return an object with validTemplate = false, 1 crit errors', () => {

--- a/src/test/yamlSchema.ts
+++ b/src/test/yamlSchema.ts
@@ -1,0 +1,38 @@
+import buildYamlSchema, * as yamlSchema from '../yamlSchema';
+import yaml = require('js-yaml');
+import assert = require('assert');
+
+describe('yamlSchema', () => {
+    describe('buildYamlSchema', () => {
+        it('should build a yaml schema', () => {
+            assert(buildYamlSchema() instanceof yaml.Schema, 'yamlSchema didn\'t return a yaml schema');
+        })
+    });
+
+    describe('functionTag', () => {
+        it('should work on a Fn::Thing', () => {
+            assert.strictEqual(yamlSchema.functionTag('Fn::Name'), 'Name');
+        })
+        it('should work on a Thing', () => {
+            assert.strictEqual(yamlSchema.functionTag('Name'), 'Name');
+        })
+    });
+
+    describe('buildYamlType', () => {
+        it('should return a type that builds the JSON representation of the yaml tag', () => {
+            const type = yamlSchema.buildYamlType('Fn::Join', 'sequence');
+            const input = ['asdf', 'asdf'];
+            const representation = type.construct(input);
+            assert.deepStrictEqual(representation, {'Fn::Join': ['asdf', 'asdf']});
+        });
+
+        it('should special-case Fn::GetAtt', () => {
+            const type = yamlSchema.buildYamlType('Fn::GetAtt', 'scalar');
+            const input = 'Resource.Attribute';
+            const representation = type.construct(input);
+            assert.deepStrictEqual(representation, {'Fn::GetAtt': ['Resource', 'Attribute']});
+        })
+    })
+
+
+})

--- a/src/util/isObject.ts
+++ b/src/util/isObject.ts
@@ -1,0 +1,4 @@
+export = function (obj: any) {
+    return (typeof obj === 'object')
+        && Object.getPrototypeOf(obj) === Object.prototype;
+}

--- a/src/util/objectMap.ts
+++ b/src/util/objectMap.ts
@@ -1,0 +1,7 @@
+export = function objectMap<O, T>(o: O, map: (v: O[keyof O]) => T) {
+    const ret = {} as {[k in keyof O]: T};
+    for (const k in o) {
+        ret[k] = map(o[k]);
+    }
+    return ret;
+}

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -522,7 +522,19 @@ function resolveCondition(ref: any, key: string){
     return condition;
 }
 
-function resolveIntrinsicFunction(ref: any, key: string) : string | boolean | string[] | undefined | null{
+function resolveIntrinsicFunction(ref: any, key: string) : string | boolean | string[] | undefined | null {
+    try {
+        const value = _resolveIntrinsicFunction(ref, key);
+        return value;
+    } catch (e) {
+        if (e instanceof IntrinsicError) {
+            addError('crit', e.message, placeInTemplate, key);
+            return `INVALID_${key}`
+        }
+    }
+}
+
+function _resolveIntrinsicFunction(ref: any, key: string) : string | boolean | string[] | undefined | null{
     switch(key){
         case 'Ref':
             return doIntrinsicRef(ref, key);
@@ -560,50 +572,166 @@ function resolveIntrinsicFunction(ref: any, key: string) : string | boolean | st
     }
 }
 
+function _resolveValue<T>(value: Resolveable<T>) {
+    if (isIntrinsic(value)) {
+        return value();
+    } else {
+        return value;
+    }
+}
+
+function _resolve<T>(value: Resolveable<T>): T {
+    const resolved = _resolveValue(value);
+    if (Array.isArray(resolved)) {
+        return resolved.map(_resolve) as any as T;
+    } else if (isObject(resolved)) {
+        return objectMap(resolved, _resolve) as any as T;
+    } else {
+        return resolved;
+    }
+}
+
+class IntrinsicError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
 function doIntrinsicRef(ref: any, key: string){
 
-    let refValue = ref[key];
-    let resolvedVal = "INVALID_REF";
+    const refValue = ref[key];
 
     // Check if it's of a String type
-    if(typeof refValue != "string"){
-        addError("crit", "Intrinsic Function Ref expects a string", placeInTemplate, "Ref");
-    }else {
-        // Check if the value of the Ref exists
-        resolvedVal = getRef(refValue);
-        if (resolvedVal === null) {
-            addError('crit', `Referenced value ${refValue} does not exist`, placeInTemplate, "Ref");
-            resolvedVal = "INVALID_REF";
-        }
+    if (typeof refValue !== "string"){
+        throw new IntrinsicError('Intrinsic Function Ref expects a string');
     }
+
 
     // Return the resolved value
     return resolvedVal;
 
 }
 
-function doIntrinsicBase64(ref: any, key: string){
-    // Only base64 encode strings
-    let toEncode = ref[key];
-    if(typeof toEncode != "string"){
-        toEncode = resolveIntrinsicFunction(ref[key], Object.keys(ref[key])[0]);
-        if(typeof toEncode != "string"){
-            addError("crit", "Parameter of Fn::Base64 does not resolve to a string", placeInTemplate, "Fn::Base64");
-            return "INVALID_FN_BASE64";
+type Resolveable<T> = T | BoundIntrinsic<T>;
+
+
+type BoundIntrinsic<T> = () => T;
+
+function Intrinsic<A, T> (fnName: string, f: (this: Intrinsic<A, T>, arg: A) => T)  {
+    const boundF = (arg: A) => f.bind(null, arg);
+    const intrinsic: Intrinsic<A, T> = Object.setPrototypeOf(boundF, Intrinsic);
+    intrinsic.fnName = fnName;
+    return intrinsic;
+}
+Intrinsic.prototype = Object.create(Function.prototype, {
+    resolve: {
+        value: function<T> (r: Resolveable<T>) {
+            return _resolve(r);
         }
     }
-    // Return base64
-    return Buffer.from(toEncode).toString('base64');
+});
+
+interface Intrinsic<A, T> {
+    (a: A): BoundIntrinsic<T>;
+    resolve: <R>(r: Resolveable<R>) => R;
+    fnName: string
 }
+
+function isIntrinsic<T>(f: any): f is BoundIntrinsic<T> {
+    return (f instanceof Intrinsic);
+}
+
+/*class Intrinsic<A, T> {
+
+    constructor(f: (this: Intrinsic<A, T>, arg: A) => T): (arg: A) => BoundIntrinsic<T>  {
+        const boundF = (arg: A) => f.bind(null, arg);
+        Object.setPrototypeOf(boundF, Intrinsic);
+    }
+
+    bind(arg: A) {
+        this.arg = arg;
+    }
+
+    resolve<T>(r: Resolveable<T>) {
+        return resolve(r);
+    }
+}
+*/
+
+const Ref = Intrinsic('Ref', function (reference: string) {
+    // Check if the value of the Ref exists
+    const resolvedVal = getRef(reference);
+    if (resolvedVal === null) {
+        throw new IntrinsicError(`Referenced value ${reference} does not exist`)
+    }
+    return resolvedVal;
+});
+
+function doIntrinsicBase64(ref: any, key: string){
+    // Only base64 encode strings
+    const toEncode = ref[key];
+    let strToEncode: string;
+
+    if (typeof toEncode === 'object') {
+        const resolved = resolveIntrinsicFunction(toEncode, Object.keys(toEncode)[0]);
+        strToEncode = resolved;
+    } else if (typeof toEncode === 'string') {
+        strToEncode = toEncode;
+    } else {
+        throw new IntrinsicError('Parameter of Fn::Base64 needs to be a string or an allowed intrinsic.');
+    }
+
+    // Return base64
+    return Buffer.from(strToEncode).toString('base64');
+}
+
+const Base64 = Intrinsic('Fn::Base64', function (value: string | BoundIntrinsic<string>) {
+    const resolved = this.resolve(value);
+
+    if (typeof value !== "string"){
+        throw new IntrinsicError('Parameter of Fn::Base64 is not a string');
+    }
+
+    return Buffer.from(value).toString('base64');
+})
+
+const Join = Intrinsic('Fn::Join', (args: [string, Resolveable<string>[]]) => {
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw new IntrinsicError('Invalid parameters for Fn::Join');
+    }
+
+    const joiner = args[0];
+    const parts = args[1];
+
+    const resolvedParts = parts.map((part) => resolve(part));
+
+    return parts.join(joiner);
+
+});
+
 
 function doIntrinsicJoin(ref: any, key: string){
     // Ensure that all objects in the join array have been resolved to string, otherwise
     // we need to resolve them.
     // Expect 2 parameters
+
+    const args = ref[key];
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw new IntrinsicError('Invalid parameters for Fn::Join');
+    }
+
+
+    if (typeof joiner !== 'string') {
+        throw new IntrinsicError('Invalid joiner for Fn::Join. You need to pass a string.');
+    }
+
+    if (typeof )
     let join = ref[key][0];
     let parts = ref[key][1] || null;
     if(ref[key].length != 2 || parts == null){
-        addError('crit', 'Invalid parameters for Fn::Join', placeInTemplate, "Fn::Join");
+        addError('crit', , placeInTemplate, "Fn::Join");
         // Specify this as an invalid string
         return "INVALID_JOIN";
     }else{
@@ -611,6 +739,31 @@ function doIntrinsicJoin(ref: any, key: string){
         return fnJoin(join, parts);
     }
 }
+
+const GetAtt = Intrinsic('Fn::GetAtt', function (args: [string, Resolveable<string>]) {
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw new IntrinsicError('Invalid parameters for Fn::GetAtt');
+    }
+
+    const reference = args[0];
+    if (typeof reference !== 'string') {
+        throw new IntrinsicError('Fn::GetAtt does not support functions for the logical resource name');
+    }
+
+    const attributeName = this.resolve(args[1]);
+    if (typeof attributeName !== 'string') {
+        throw new IntrinsicError('Fn::GetAtt needs a string for the attribute to get.');
+    }
+
+    const resolved = fnGetAtt(reference, attributeName);
+
+    if (resolved === null) {
+        throw new IntrinsicError(`Invalid GetAtt - ${reference}.${attributeName}`);
+    }
+
+    return resolved;
+});
 
 function doIntrinsicGetAtt(ref: any, key: string){
     let toGet = ref[key];
@@ -647,6 +800,29 @@ function doIntrinsicGetAtt(ref: any, key: string){
     }
 }
 
+const FindInMap = Intrinsic('Fn::FindInMap', function (args: Resolveable<string>[]) {
+
+    if (!Array.isArray(args) || args.length !== 3) {
+        throw new IntrinsicError('Invalid parameters for Fn::FindInMap');
+    }
+
+    const toGet = args.map((arg) => this.resolve(arg));
+
+    for (const r of toGet) {
+        if (typeof r !== 'string') {
+            throw new IntrinsicError('Invalid parameter r for Fn::FindInMap. It needs a string.');
+        }
+    }
+
+    const value = fnFindInMap(toGet[0], toGet[1], toGet[2]);
+    if (value == null) {
+        throw new IntrinsicError(`Could not find value in map ${toGet[0]}|${toGet[1]}|${toGet[2]}. Have you tried specifying input parameters?`);
+    }
+
+    return value;
+
+})
+
 function doIntrinsicFindInMap(ref: any, key: string){
     let toGet = ref[key];
     if(toGet.length != 3){
@@ -677,6 +853,22 @@ function doIntrinsicFindInMap(ref: any, key: string){
     }
 }
 
+const GetAZs = Intrinsic('Fn::GetAZs', function (arg: Resolveable<string>) {
+    const region = this.resolve(arg);
+
+    if (typeof region !== 'string') {
+        throw new IntrinsicError('Fn::GetAZs only supports Ref or string as a parameter');
+    }
+
+    // TODO
+    // if(toGet[key] != 'AWS::Region'){
+    //     addError("warn", "Fn::GetAZs expects a region, ensure this reference returns a region", placeInTemplate, "Fn::GetAZs");
+    // }
+
+    const AZs = ['a', 'b', 'c'].map((s) => `${region}${s}`);
+    return AZs;
+})
+
 function doIntrinsicGetAZs(ref: any, key: string){
     let toGet = ref[key];
     let region = awsRefOverrides['AWS::Region'];
@@ -706,6 +898,33 @@ function doIntrinsicGetAZs(ref: any, key: string){
     return AZs;
 
 }
+
+const Select = Intrinsic('Fn::Select', function (arg: [Resolveable<string|number>, Resolveable<any[]>]) {
+    if (!Array.isArray(arg) || arg.length !== 2) {
+        throw new IntrinsicError('Fn::Select only supports an array ot two elements');
+    }
+
+    const indexStr = this.resolve(arg[0]);
+    if (!isInteger(indexStr)) {
+        throw new IntrinsicError("Fn::Select's first argument did not resolve to a string for parsing or a numeric value.");
+    }
+
+    const index = parseInt(indexStr as string);
+    if (!isNaN(index)) {
+        throw new IntrinsicError('First element of Fn::Select must be a number, or it must use an intrinsic fuction that returns a number')
+    }
+
+    const list = this.resolve(arg[1]);
+    if (!Array.isArray(list)) {
+        throw new IntrinsicError(`Fn::Select requires the second element to be a list, function call did not resolve to a list. It contains value ${list}`);
+    }
+
+    if (index < 0 || index >= list.length) {
+        throw new IntrinsicError("First element of Fn::Select exceeds the length of the list.");
+    }
+
+    return list[index];
+})
 
 function doIntrinsicSelect(ref: any, key: string){
     let toGet = ref[key];
@@ -783,7 +1002,7 @@ function doIntrinsicSelect(ref: any, key: string){
         }
     } else if (list.indexOf(null) > -1) {
         addError('crit', "Fn::Select requires that the list be free of null values", placeInTemplate, "Fn::Select");
-    
+
     }
     if (index >= 0 && index < list.length) {
         return list[index];
@@ -794,6 +1013,74 @@ function doIntrinsicSelect(ref: any, key: string){
 
 
 }
+
+function objectMap<O, T>(o: O, map: (v: O[keyof O]) => T) {
+    const ret = {} as {[k: keyof O]: T};
+    for (const k in o) {
+        ret[k] = map(o[k]);
+    }
+    return ret;
+}
+
+function fnSub(replacementString: string, vars: {[k: string]: any}) {
+    const regex = /\${([A-Za-z0-9:.!]+)/gm;
+
+    return replacementString.replace(regex, (_: string, subMatch: string) => {
+        if (subMatch.indexOf('!') === 1) {
+            return subMatch;
+        } else if (subMatch in vars) {
+            return vars[subMatch];
+        } else if (subMatch.indexOf('.') !== -1) {
+            const [resource, ...attributes] = subMatch.split('.');
+            const joinedAttribute = attributes.join('.');
+            const resolved = fnGetAtt(resource, joinedAttribute);
+            if (resolved == null) {
+                throw new IntrinsicError(`Intrinsic Sub does not reference valid resource attribute '${subMatch}'`);
+            }
+            return resolved;
+        } else {
+            const resolved = getRef(subMatch);
+            if (resolved == null) {
+                throw new IntrinsicError(`Intrinsic Sub does not reference valid resource or mapping '${subMatch}'`);
+            }
+            return resolved;
+        }
+    });
+
+}
+
+function doSubOnString(str: string) {
+    return fnSub(str, {});
+}
+
+function doSubOnArray(this: any, arg: [string, {[k: string]: any}]) {
+    const replacementString = arg[0];
+    if (typeof replacementString !== 'string') {
+        throw new IntrinsicError('Fn::Sub expects first argument to be a string');
+    }
+
+    const mapping = resolve(arg[1]);
+    if (typeof mapping !== 'object') {
+        throw new IntrinsicError('Fn::Sub expects second argument to be a variable map');
+    }
+
+    const vars = objectMap(mapping, (v) => this.resolve(v));
+
+    return fnSub(replacementString, vars);
+}
+
+
+const Sub = Intrinsic('Fn::Sub', function (arg: string | [string, {[k: string]: any}]) {
+
+    if (typeof arg === 'string') {
+        return doSubOnString(arg);
+    } else if (Array.isArray(arg) && arg.length === 2) {
+        return doSubOnArray(arg);
+    } else {
+        throw new IntrinsicError('Fn::Sub needs a string or an array of length 2.');
+    }
+
+})
 
 function doIntrinsicSub(ref: any, key: string){
     let toGet = ref[key];
@@ -827,11 +1114,6 @@ function doIntrinsicSub(ref: any, key: string){
 
     // Extract the replacement parts
     let regex = /\${([A-Za-z0-9:.!]+)/gm;
-    let matches = [];
-    let match;
-    while (match = regex.exec(replacementStr)) {
-        matches.push(match[1]);
-    }
 
     // Resolve the replacement and replace into string using Ref or GetAtt
     for(let m of matches){
@@ -878,6 +1160,23 @@ function doIntrinsicSub(ref: any, key: string){
     return replacementStr;
 }
 
+const If = Intrinsic('Fn::If', function (arg: [string, Resolveable<any>, Resolveable<any>]) {
+    if (!Array.isArray(arg) || arg.length !== 3) {
+        throw new IntrinsicError(`Fn::If must be an array with 3 arguments.`);
+    }
+
+    const condition = arg[0];
+    const ifTrue = arg[1];
+    const ifFalse = arg[2];
+    const conditionValue = resolveCondition({'Condition': arg[0]}, 'Condition');
+
+    if (conditionValue) {
+        return this.resolve(ifTrue);
+    } else {
+        return this.resolve(ifFalse);
+    }
+})
+
 function doIntrinsicIf(ref: any, key: string){
     let toGet = ref[key];
 
@@ -920,13 +1219,24 @@ function doIntrinsicIf(ref: any, key: string){
         }
 
     }else{
-        addError('crit', `Fn::If must have 3 arguments, only ${toGet.length} given.`, placeInTemplate, 'Fn::If');
+        addError('crit', ``, placeInTemplate, 'Fn::If');
     }
 
     // Set the 1st or 2nd param as according to the condition
 
     return "INVALID_IF_STATEMENT";
 }
+
+const Equals = Intrinsic('Fn::Equals', function (arg: [Resolveable<any>, Resolveable<any>]) {
+    if (!Array.isArray(arg) || arg.length !== 2) {
+        throw new IntrinsicError('Fn::Equals expects an array with 2 arguments.');
+    }
+
+    const v1 = this.resolve(arg[0]);
+    const v2 = this.resolve(arg[1]);
+
+    return (v1 == v2);
+})
 
 function doIntrinsicEquals(ref: any, key: string) {
     let toGet = ref[key];
@@ -964,6 +1274,14 @@ function doIntrinsicEquals(ref: any, key: string) {
     return false;
 }
 
+const Or = Intrinsic('Fn::Or', function (arg: any[]) {
+    if (!Array.isArray(arg) || arg.length < 2 || arg.length > 10) {
+        throw new IntrinsicError('Fn::Or wants an array of between 2 and 10 arguments');
+    }
+
+    return Boolean(arg.find((condition) => this.resolve(condition === true)));
+});
+
 function doIntrinsicOr(ref: any, key: string) {
     let toGet = ref[key];
 
@@ -995,6 +1313,20 @@ function doIntrinsicOr(ref: any, key: string) {
         addError('crit', `Expecting Fn::Or to have between 2 and 10 arguments`, placeInTemplate, 'Fn::Or');
     }
 }
+
+const Not = Intrinsic('Fn::Not', function (arg: [Resolveable<boolean>]) {
+    if (!Array.isArray(arg) || arg.length !== 1) {
+        throw new IntrinsicError('Fn::Not expects an array of length 1');
+    }
+
+    const condition = this.resolve(arg);
+
+    if (typeof condition !== 'boolean') {
+        throw new IntrinsicError(`Fn::Not did not resolve to a boolean value, ${condition} given`);
+    }
+
+    return !condition;
+})
 
 function doIntrinsicNot(ref: any, key: string){
 
@@ -1028,6 +1360,15 @@ function doIntrinsicNot(ref: any, key: string){
     return false;
 }
 
+const ImportValue = Intrinsic('Fn::ImportValue', function (arg: Resolveable<string>) {
+    const importName = resolve(arg);
+    if (importName !== 'string') {
+        throw new IntrinsicError('Something went wrong when resolving references for a Fn::ImportValue');
+    }
+
+    return `IMPORTEDVALUE${importName}`;
+});
+
 function doIntrinsicImportValue(ref: any, key: string){
     let toGet = ref[key];
 
@@ -1050,6 +1391,26 @@ function doIntrinsicImportValue(ref: any, key: string){
         return 'INVALID_FN_IMPORTVALUE';
     }
 }
+
+const Split = Intrinsic('Fn::Split', function (args: [string, Resolveable<string>]) {
+
+    if (!Array.isArray(args) || args.length !== 2) {
+        throw new IntrinsicError('Invalid parameter for Fn::Split. It needs an Array of length 2.');
+    }
+
+    const delimiter = args[0];
+    if (typeof delimiter !== 'string') {
+        throw new IntrinsicError(`Invalid parameter for Fn::Split. The delimiter, ${util.inspect(delimiter)}, needs to be a string.`);
+    }
+
+    const stringToSplit = this.resolve(args[1]);
+    if (typeof stringToSplit !== 'string') {
+        throw new IntrinsicError(`Invalid parameters for Fn::Split. The parameter, ${stringToSplit}, needs to be a string or a supported intrinsic function.`);
+    }
+
+    return stringToSplit.split(delimiter);
+
+});
 
 export function doInstrinsicSplit(ref: any, key: string): string[] {
     const args = ref[key];
@@ -1247,7 +1608,7 @@ export interface PrimitiveType {
     resourceType: string,
     primitiveType: string
 }
-  
+
 export type ObjectType = ResourceType | NamedProperty | PropertyType | PrimitiveType;
 
 /**
@@ -1267,7 +1628,7 @@ function getTypeName(objectType: ResourceType | NamedProperty | PropertyType ): 
 }
 
 /**
- * 
+ *
  */
 function getItemType(objectType: NamedProperty): PrimitiveType | PropertyType {
     const maybePrimitiveType = resourcesSpec.getPrimitiveItemType(objectType.parentType, objectType.propertyName);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -143,11 +143,12 @@ function validateWorkingInput(passedOptions?: Partial<ValidateOptions>) {
     // Check parameters and assign outputs
     assignParametersOutput(options.guessParameters);
 
+    assignIntrinsics(workingInput);
+
     // Evaluate Conditions
-    assignConditionsOutputs();
+    checkConditions(workingInput['Conditions'], ['Conditions']);
 
     // Assign intrinsic resolvers
-    assignIntrinsics();
 
     // Assign outputs to all the resources
     assignResourcesOutputs();
@@ -159,17 +160,72 @@ function validateWorkingInput(passedOptions?: Partial<ValidateOptions>) {
         return errorObject;
     }
 
-    // Use the outputs assigned to resources to resolve references
-    resolveReferences();
-
     // Go through the hopefully resolved properties of each resource
     checkResourceProperties();
+
+    checkUncalledIntrinsics();
 
     // Assign template outputs to the error object
     collectOutputs();
 
     return errorObject;
 
+}
+
+function assignIntrinsics(tree: any) {
+    const placeInTemplate: BreadcrumbTrail = [];
+
+    _assignIntrinsics(
+        tree['Conditions'],
+        placeInTemplate.concat(['Conditions']),
+        ['Fn::And', 'Fn::Equals', 'Fn::If', 'Fn::Not', 'Fn::Or']
+    );
+    _assignIntrinsics(tree['Resources'], placeInTemplate.concat(['Resources']));
+    _assignIntrinsics(tree['Metadata'], placeInTemplate.concat(['Metadata']));
+    _assignIntrinsics(tree['Outputs'], placeInTemplate.concat(['Outputs']));
+}
+
+export function isIntrinsic(object: any, placeInTemplate: BreadcrumbTrail, allowedIntrinsicFunctions?: string[]): false | intrinsics.BoundIntrinsic<any, any> {
+    if (typeof object !== 'object') { return false; }
+    const objectPrototype = Object.getPrototypeOf(object);
+    if (!(objectPrototype === Object.prototype || objectPrototype === null)) { return false; }
+
+    const keys = Object.keys(object);
+    const firstKey = keys[keys.length-1];
+
+    if (!(firstKey in awsIntrinsicFunctions)) { return false; }
+
+    if (allowedIntrinsicFunctions !== undefined
+        && allowedIntrinsicFunctions.indexOf(firstKey) < 0) {
+        addError('crit', `${firstKey} is not allowed to be used here. You can only used one of ${allowedIntrinsicFunctions.join(',')}.`, placeInTemplate)
+    }
+
+    if (keys.length > 1) {
+        addError('warn', 'You have passed an intrinsic function with more than one key, this is probably an error.', placeInTemplate, 'Intrinsic Functions');
+    }
+
+    const fnName = firstKey;
+    const args = object[firstKey];
+
+    return buildIntrinsic(fnName, args, placeInTemplate.concat([fnName]));
+}
+
+// Depth first search, assigning intrinsics
+export function _assignIntrinsics(tree: any, placeInTemplate: BreadcrumbTrail, allowedIntrinsicFunctions?: string[]) {
+    if (Array.isArray(tree)) {
+        for (const index in tree) {
+            tree[index] = _assignIntrinsics(tree[index], placeInTemplate.concat([index]), allowedIntrinsicFunctions);
+        }
+    } else if (typeof tree === 'object' && (Object.getPrototypeOf(tree) === Object.prototype)) {
+        for (const index in tree) {
+            tree[index] = _assignIntrinsics(tree[index], placeInTemplate.concat([index]), allowedIntrinsicFunctions);
+        }
+    }
+
+    const maybeIntrinsic = isIntrinsic(tree, placeInTemplate);
+    return (maybeIntrinsic === false)
+        ? tree
+        : maybeIntrinsic;
 }
 
 function assignParametersOutput(guessParameters?: string[]) {
@@ -227,7 +283,7 @@ function assignParametersOutput(guessParameters?: string[]) {
         // Assign an Attribute Ref regardless of any failures above
         workingInput['Parameters'][parameterName]['Attributes'] = {};
         workingInput['Parameters'][parameterName]['Attributes']['Ref'] = parameterValue;
-    
+
     }
 }
 
@@ -282,7 +338,7 @@ function inferParameterValue(parameterName: string, parameter: any, okToGuess: b
                 normalizedType = 'string';
             }
 
-            const parameterDefault = parameterDefaultsByType[parameterTypesSpec[parameterType]!]! 
+            const parameterDefault = parameterDefaultsByType[parameterTypesSpec[parameterType]!]!
             if (isList) {
                 return [parameterDefault];
             } else {
@@ -316,58 +372,22 @@ function addError(severity: Severity, message : string, resourceStack: typeof pl
     }
 }
 
-function assignConditionsOutputs(){
+function checkConditions(conditionsTree: any, placeInTemplate: BreadcrumbTrail) {
 
-    let allowedIntrinsicFunctions = ['Fn::And', 'Fn::Equals', 'Fn::If', 'Fn::Not', 'Fn::Or'];
+    for (const conditionName in conditionsTree) {
 
-    if(!workingInput.hasOwnProperty('Conditions')){
-        return;
-    }
+        const condition = conditionsTree[conditionName];
 
-    // For through each condition
-    placeInTemplate.push('Conditions');
-    for(let cond in workingInput['Conditions']) {
-        if (workingInput['Conditions'].hasOwnProperty(cond)) {
-            placeInTemplate.push(cond);
-            let condition = workingInput['Conditions'][cond];
-
-            // Check the value of condition is an object
-            if(typeof condition != 'object'){
-                addError('crit', `Condition should consist of an intrinsic function of type ${allowedIntrinsicFunctions.join(', ')}`,
-                                placeInTemplate,
-                                'Conditions');
-                workingInput['Conditions'][cond] = {};
-                workingInput['Conditions'][cond]['Attributes'] = {};
-                workingInput['Conditions'][cond]['Attributes']['Output'] = false;
-            }else{
-                // Check the value of this is Fn::And, Fn::Equals, Fn::If, Fn::Not or Fn::Or
-                let keys = Object.keys(condition);
-                if(allowedIntrinsicFunctions.indexOf(keys[0]) != -1){
-
-                    // Resolve recursively
-                    let val = resolveIntrinsicFunction(condition, keys[0]);
-
-                    // Check is boolean type
-                    workingInput['Conditions'][cond]['Attributes'] = {};
-                    workingInput['Conditions'][cond]['Attributes']['Output'] = false;
-                    if(val === true || val === false){
-                        workingInput['Conditions'][cond]['Attributes']['Output'] = val;
-                    }else{
-                        addError('crit', `Condition did not resolve to a boolean value, got ${val}`, placeInTemplate, 'Conditions');
-                    }
-
-                }else{
-                    // Invalid intrinsic function
-                    addError('crit', `Condition does not allow function '${keys[0]}' here`, placeInTemplate, 'Conditions');
-                }
-            }
-
-
-            placeInTemplate.pop();
+        const allowedIntrinsicFunctions: string[] = []; // TODO
+        // Check the value of condition is an object
+        if (!(condition instanceof intrinsics.BoundIntrinsic)) {
+            addError('crit', `Condition should consist of an intrinsic function of type ${allowedIntrinsicFunctions.join(', ')}`,
+                            placeInTemplate,
+                            'Conditions');
+        } else {
+            resolveIntrinsic(condition);
         }
     }
-    placeInTemplate.pop();
-
 }
 
 function assignResourcesOutputs(){
@@ -448,452 +468,43 @@ function assignResourcesOutputs(){
 
 }
 
-function resolveReferences(){
-    // TODO: Go through and resolve...
-    // TODO: Ref, Attr, Join,
-
-    // Resolve all Ref
-    lastPositionInTemplate = workingInput;
-    recursiveDescent(lastPositionInTemplate);
-
-
-    let stop = workingInput;
-
-}
-
-let placeInTemplate: (string|number)[] = [];
+export type BreadcrumbTrail = (string|number)[];
+let placeInTemplate: BreadcrumbTrail = [];
 let lastPositionInTemplate: any = null;
 let lastPositionInTemplateKey: string | null = null;
-
-function recursiveDescent(ref: any){
-    // Step into next attribute
-    for(let i=0; i < Object.keys(ref).length; i++){
-        let key = Object.keys(ref)[i];
-
-        // Resolve the function
-        if(awsIntrinsicFunctions.hasOwnProperty(key)){
-
-            // Check if an Intrinsic function is allowed here
-            let inResourceProperty = (placeInTemplate[0] == "Resources" || placeInTemplate[2] == "Properties");
-            let inResourceMetadata = (placeInTemplate[0] == "Resources" || placeInTemplate[2] == "Metadata");
-            let inOutputs = (placeInTemplate[0] == "Outputs");
-            let inConditions = (placeInTemplate[0] == "Conditions");
-            // TODO Check for usage inside update policy
-
-            if(!(inResourceProperty || inResourceMetadata || inOutputs || inConditions)){
-                addError("crit", `Intrinsic function ${key} is not supported here`, placeInTemplate, key);
-            } else {
-                // Resolve the function
-                const boundIntrinsic = buildIntrinsic(ref, key);
-                // Overwrite the position with the resolved value
-                lastPositionInTemplate[lastPositionInTemplateKey!] = boundIntrinsic;
-            }
-        }else if(key != 'Attributes' && ref[key] instanceof Object){
-            placeInTemplate.push(key);
-            lastPositionInTemplate = ref;
-            lastPositionInTemplateKey = key;
-            recursiveDescent(ref[key]);
-        }
-
-
-    }
-    placeInTemplate.pop();
-}
-
-function resolveCondition(ref: any, key: string){
-    let toGet = ref[key];
-    let condition = false;
-
-    if(workingInput.hasOwnProperty('Conditions') && workingInput['Conditions'].hasOwnProperty(toGet)){
-
-        // Check the valid of the condition, returning argument 1 on true or 2 on failure
-        if(typeof workingInput['Conditions'][toGet] == 'object') {
-            if (workingInput['Conditions'][toGet].hasOwnProperty('Attributes') &&
-                workingInput['Conditions'][toGet]['Attributes'].hasOwnProperty('Output')) {
-                condition = workingInput['Conditions'][toGet]['Attributes']['Output'];
-            }   // If invalid, we will default to false, a previous error would have been thrown
-        }else{
-            condition = workingInput['Conditions'][toGet];
-        }
-
-    }else{
-        addError('crit', `Condition '${toGet}' must reference a valid condition`, placeInTemplate, 'Condition');
-    }
-
-    return condition;
-}
-
-function buildIntrinsic(ref: any, key: string) {
-    const fnName = key;
-    const arg = ref[key];
-
-    if (!(fnName in intrinsics)) {
-        addError("warn", `Unhandled Intrinsic Function ${key}, this needs implementing. Some errors might be missed.`, placeInTemplate, "Functions");
-        return () => 'UNHANDLED_INTRINSIC';
-    }
-
-    return intrinsics[key](arg);
-}
-
-const intrinsics: {[k: string]: Intrinsic<any, any>} = {};
-
-function _resolveValue<T>(value: Resolveable<T>): T | string {
-    if (isBoundIntrinsic(value)) {
-        try {
-            return value();
-        } catch (e) {
-            if (e instanceof IntrinsicError) {
-                addError('crit', e.message, placeInTemplate, value.fnName);
-                return `INVALID_${value.fnName}`;
-            } else {
-                throw e;
-            }
-        }
-    } else {
-        return value;
-    }
-}
-
-function _resolve<T>(value: Resolveable<T>): T | string {
-    const resolved = _resolveValue(value);
-    if (Array.isArray(resolved)) {
-        return resolved.map(_resolve) as any as T;
-    } else if (isObject(resolved)) {
-        return objectMap(resolved, _resolve) as any as T;
-    } else {
-        return resolved;
-    }
-}
-
-class IntrinsicError extends Error {
-    constructor(message: string) {
-        super(message);
-    }
-}
-
-type Resolveable<T> = T | BoundIntrinsic<T>;
-
-
-interface BoundIntrinsic<T> {
-    (): T;
-    fnName: string
-}
-
-function Intrinsic<A, T> (fnName: string, f: (this: Intrinsic<A, T>, arg: A) => T): Intrinsic<A, T>  {
-    const builder = (arg: A) => BoundIntrinsic(fnName, f, arg);
-    const intrinsic: Intrinsic<A, T> = Object.setPrototypeOf(builder, Intrinsic.prototype);
-    intrinsic.fnName = fnName;
-    intrinsics[fnName] = intrinsic;
-    return intrinsic;
-}
-Intrinsic.prototype = Object.create(Function.prototype, {
-    resolve: {
-        value: function<T> (r: Resolveable<T>) {
-            return _resolve(r);
-        }
-    }
-});
-
-function BoundIntrinsic<A, T>(fnName: string, f: (a: A) => T, arg: A): BoundIntrinsic<T> {
-    const boundF = Object.setPrototypeOf(f.bind(null, arg), BoundIntrinsic.prototype);
-    return Object.assign(boundF, {fnName});
-}
-BoundIntrinsic.prototype = Object.create(Function.prototype);
-
-interface Intrinsic<A, T> {
-    (a: A): BoundIntrinsic<T>;
-    resolve: <R>(r: Resolveable<R>) => R;
-    fnName: string
-}
-
-function isBoundIntrinsic<T>(f: any): f is BoundIntrinsic<T> {
-    return (f instanceof Intrinsic);
-}
-
-/*class Intrinsic<A, T> {
-
-    constructor(f: (this: Intrinsic<A, T>, arg: A) => T): (arg: A) => BoundIntrinsic<T>  {
-        const boundF = (arg: A) => f.bind(null, arg);
-        Object.setPrototypeOf(boundF, Intrinsic);
-    }
-
-    bind(arg: A) {
-        this.arg = arg;
-    }
-
-    resolve<T>(r: Resolveable<T>) {
-        return resolve(r);
-    }
-}
-*/
-
-const Ref = Intrinsic('Ref', function (reference: string) {
-    // Check if the value of the Ref exists
-    const resolvedVal = getRef(reference);
-    if (resolvedVal === null) {
-        throw new IntrinsicError(`Referenced value ${reference} does not exist`)
-    }
-    return resolvedVal;
-});
-
-const Base64 = Intrinsic('Fn::Base64', function (value: string | BoundIntrinsic<string>) {
-    const resolved = this.resolve(value);
-
-    if (typeof value !== "string"){
-        throw new IntrinsicError('Parameter of Fn::Base64 is not a string');
-    }
-
-    return Buffer.from(value).toString('base64');
-})
-
-const Join = Intrinsic('Fn::Join', function (args: [string, Resolveable<string>[]]) {
-
-    if (!Array.isArray(args) || args.length !== 2) {
-        throw new IntrinsicError('Invalid parameters for Fn::Join');
-    }
-
-    const joiner = args[0];
-    const parts = args[1];
-
-    const resolvedParts = parts.map((part) => this.resolve(part));
-
-    return parts.join(joiner);
-
-});
-
-const GetAtt = Intrinsic('Fn::GetAtt', function (args: [string, Resolveable<string>]) {
-    if (!Array.isArray(args) || args.length !== 2) {
-        throw new IntrinsicError('Invalid parameters for Fn::GetAtt');
-    }
-
-    const reference = args[0];
-    if (typeof reference !== 'string') {
-        throw new IntrinsicError('Fn::GetAtt does not support functions for the logical resource name');
-    }
-
-    const attributeName = this.resolve(args[1]);
-    if (typeof attributeName !== 'string') {
-        throw new IntrinsicError('Fn::GetAtt needs a string for the attribute to get.');
-    }
-
-    const resolved = fnGetAtt(reference, attributeName);
-
-    if (resolved === null) {
-        throw new IntrinsicError(`Invalid GetAtt - ${reference}.${attributeName}`);
-    }
-
-    return resolved;
-});
-
-const FindInMap = Intrinsic('Fn::FindInMap', function (args: Resolveable<string>[]) {
-
-    if (!Array.isArray(args) || args.length !== 3) {
-        throw new IntrinsicError('Invalid parameters for Fn::FindInMap');
-    }
-
-    const toGet = args.map((arg) => this.resolve(arg));
-
-    if (toGet.findIndex((r) => (typeof r !== 'string')) > -1) {
-        throw new IntrinsicError('Invalid parameter for Fn::FindInMap. It needs a string.');
-    }
-
-    const value = fnFindInMap(toGet[0], toGet[1], toGet[2]);
-    if (value == null) {
-        throw new IntrinsicError(`Could not find value in map ${toGet[0]}|${toGet[1]}|${toGet[2]}. Have you tried specifying input parameters?`);
-    }
-
-    return value;
-
-})
-
-const GetAZs = Intrinsic('Fn::GetAZs', function (arg: Resolveable<string>) {
-    const region = this.resolve(arg);
-
-    if (typeof region !== 'string') {
-        throw new IntrinsicError('Fn::GetAZs only supports Ref or string as a parameter');
-    }
-
-    // TODO
-    // if(toGet[key] != 'AWS::Region'){
-    //     addError("warn", "Fn::GetAZs expects a region, ensure this reference returns a region", placeInTemplate, "Fn::GetAZs");
-    // }
-
-    const AZs = ['a', 'b', 'c'].map((s) => `${region}${s}`);
-    return AZs;
-})
-
-const Select = Intrinsic('Fn::Select', function (arg: [Resolveable<string|number>, Resolveable<any[]>]) {
-    if (!Array.isArray(arg) || arg.length !== 2) {
-        throw new IntrinsicError('Fn::Select only supports an array ot two elements');
-    }
-
-    const indexStr = this.resolve(arg[0]);
-    if (!isInteger(indexStr)) {
-        throw new IntrinsicError("Fn::Select's first argument did not resolve to a string for parsing or a numeric value.");
-    }
-
-    const index = parseInt(indexStr as string);
-    if (!isNaN(index)) {
-        throw new IntrinsicError('First element of Fn::Select must be a number, or it must use an intrinsic fuction that returns a number')
-    }
-
-    const list = this.resolve(arg[1]);
-    if (!Array.isArray(list)) {
-        throw new IntrinsicError(`Fn::Select requires the second element to be a list, function call did not resolve to a list. It contains value ${list}`);
-    }
-
-    if (index < 0 || index >= list.length) {
-        throw new IntrinsicError("First element of Fn::Select exceeds the length of the list.");
-    }
-
-    return list[index];
-})
-
-function objectMap<O, T>(o: O, map: (v: O[keyof O]) => T) {
-    const ret = {} as {[k in keyof O]: T};
-    for (const k in o) {
-        ret[k] = map(o[k]);
-    }
-    return ret;
-}
-
-function fnSub(replacementString: string, vars: {[k: string]: any}) {
-    const regex = /\${([A-Za-z0-9:.!]+)/gm;
-
-    return replacementString.replace(regex, (_: string, subMatch: string) => {
-        if (subMatch.indexOf('!') === 1) {
-            return subMatch;
-        } else if (subMatch in vars) {
-            return vars[subMatch];
-        } else if (subMatch.indexOf('.') !== -1) {
-            const [resource, ...attributes] = subMatch.split('.');
-            const joinedAttribute = attributes.join('.');
-            const resolved = fnGetAtt(resource, joinedAttribute);
-            if (resolved == null) {
-                throw new IntrinsicError(`Intrinsic Sub does not reference valid resource attribute '${subMatch}'`);
-            }
-            return resolved;
+const boundIntrinsics: intrinsics.BoundIntrinsic<any, any>[] = [];
+
+
+import * as intrinsics from './intrinsics';
+import {Resolveable} from './intrinsics';
+
+function buildIntrinsic(fnName: string, arg: any, placeInTemplate: BreadcrumbTrail) {
+    try {
+        const intrinsic = intrinsics._buildIntrinsic(fnName, arg, placeInTemplate, workingInput);
+        boundIntrinsics.push(intrinsic);
+        return intrinsic;
+    } catch (e) {
+        if (e instanceof intrinsics.NoSuchIntrinsic) {
+            addError("warn", `Unhandled Intrinsic Function ${fnName}, this needs implementing. Some errors might be missed.`, placeInTemplate, "Functions");
+            return intrinsics.UnhandledIntrinsic.bind(undefined, placeInTemplate, workingInput);
         } else {
-            const resolved = getRef(subMatch);
-            if (resolved == null) {
-                throw new IntrinsicError(`Intrinsic Sub does not reference valid resource or mapping '${subMatch}'`);
-            }
-            return resolved;
+            throw e;
         }
-    });
-
+    }
 }
 
-function doSubOnString(str: string) {
-    return fnSub(str, {});
+function resolveIntrinsic<T>(value: Resolveable<T>): T | string {
+    try {
+        return intrinsics.recursiveResolve(value);
+    } catch (e) {
+        if (e instanceof intrinsics.IntrinsicError) {
+            addError('crit', e.message, placeInTemplate, e.boundIntrinsic.fnName);
+            return `INVALID_${e.boundIntrinsic.fnName}`;
+        } else {
+            throw e;
+        }
+    }
 }
-
-function doSubOnArray(this: any, arg: [string, {[k: string]: any}]) {
-    const replacementString = arg[0];
-    if (typeof replacementString !== 'string') {
-        throw new IntrinsicError('Fn::Sub expects first argument to be a string');
-    }
-
-    const mapping = this.resolve(arg[1]);
-    if (typeof mapping !== 'object') {
-        throw new IntrinsicError('Fn::Sub expects second argument to be a variable map');
-    }
-
-    const vars = objectMap(mapping, (v) => this.resolve(v));
-
-    return fnSub(replacementString, vars);
-}
-
-const Sub = Intrinsic('Fn::Sub', function (arg: string | [string, {[k: string]: any}]) {
-
-    if (typeof arg === 'string') {
-        return doSubOnString(arg);
-    } else if (Array.isArray(arg) && arg.length === 2) {
-        return doSubOnArray(arg);
-    } else {
-        throw new IntrinsicError('Fn::Sub needs a string or an array of length 2.');
-    }
-
-})
-
-const If = Intrinsic('Fn::If', function (arg: [string, Resolveable<any>, Resolveable<any>]) {
-    if (!Array.isArray(arg) || arg.length !== 3) {
-        throw new IntrinsicError(`Fn::If must be an array with 3 arguments.`);
-    }
-
-    const condition = arg[0];
-    const ifTrue = arg[1];
-    const ifFalse = arg[2];
-    const conditionValue = resolveCondition({'Condition': arg[0]}, 'Condition');
-
-    if (conditionValue) {
-        return this.resolve(ifTrue);
-    } else {
-        return this.resolve(ifFalse);
-    }
-})
-
-const Equals = Intrinsic('Fn::Equals', function (arg: [Resolveable<any>, Resolveable<any>]) {
-    if (!Array.isArray(arg) || arg.length !== 2) {
-        throw new IntrinsicError('Fn::Equals expects an array with 2 arguments.');
-    }
-
-    const v1 = this.resolve(arg[0]);
-    const v2 = this.resolve(arg[1]);
-
-    return (v1 == v2);
-})
-
-const Or = Intrinsic('Fn::Or', function (arg: any[]) {
-    if (!Array.isArray(arg) || arg.length < 2 || arg.length > 10) {
-        throw new IntrinsicError('Fn::Or wants an array of between 2 and 10 arguments');
-    }
-
-    return Boolean(arg.find((condition) => this.resolve(condition === true)));
-});
-
-const Not = Intrinsic('Fn::Not', function (arg: [Resolveable<boolean>]) {
-    if (!Array.isArray(arg) || arg.length !== 1) {
-        throw new IntrinsicError('Fn::Not expects an array of length 1');
-    }
-
-    const condition = this.resolve(arg);
-
-    if (typeof condition !== 'boolean') {
-        throw new IntrinsicError(`Fn::Not did not resolve to a boolean value, ${condition} given`);
-    }
-
-    return !condition;
-})
-
-const ImportValue = Intrinsic('Fn::ImportValue', function (arg: Resolveable<string>) {
-    const importName = this.resolve(arg);
-    if (importName !== 'string') {
-        throw new IntrinsicError('Something went wrong when resolving references for a Fn::ImportValue');
-    }
-
-    return `IMPORTEDVALUE${importName}`;
-});
-
-const Split = Intrinsic('Fn::Split', function (args: [string, Resolveable<string>]) {
-
-    if (!Array.isArray(args) || args.length !== 2) {
-        throw new IntrinsicError('Invalid parameter for Fn::Split. It needs an Array of length 2.');
-    }
-
-    const delimiter = args[0];
-    if (typeof delimiter !== 'string') {
-        throw new IntrinsicError(`Invalid parameter for Fn::Split. The delimiter, ${util.inspect(delimiter)}, needs to be a string.`);
-    }
-
-    const stringToSplit = this.resolve(args[1]);
-    if (typeof stringToSplit !== 'string') {
-        throw new IntrinsicError(`Invalid parameters for Fn::Split. The parameter, ${stringToSplit}, needs to be a string or a supported intrinsic function.`);
-    }
-
-    return stringToSplit.split(delimiter);
-
-});
 
 export function fnGetAtt(reference: string, attributeName: string){
     if(workingInput['Resources'].hasOwnProperty(reference)){
@@ -934,7 +545,7 @@ export function fnGetAtt(reference: string, attributeName: string){
     return null;
 }
 
-function fnFindInMap(map: any, first: string, second: string){
+export function fnFindInMap(map: any, first: string, second: string){
     if(workingInput.hasOwnProperty('Mappings')){
         if(workingInput['Mappings'].hasOwnProperty(map)){
             if(workingInput['Mappings'][map].hasOwnProperty(first)){
@@ -947,7 +558,7 @@ function fnFindInMap(map: any, first: string, second: string){
     return null;
 }
 
-function getRef(reference: string){
+export function getRef(reference: string){
     // Check in Resources
     if(workingInput['Resources'].hasOwnProperty(reference)){
         return workingInput['Resources'][reference]['Attributes']['Ref'];
@@ -965,6 +576,12 @@ function getRef(reference: string){
 
     // We have not found a ref
     return null;
+}
+
+function checkUncalledIntrinsics() {
+    for (const boundIntrinsic of boundIntrinsics.filter((i) => !i.called)) {
+        resolveIntrinsic(boundIntrinsic); // this raises any necessary errors
+    }
 }
 
 function collectOutputs() {
@@ -1154,8 +771,11 @@ export function getPropertyType(objectType: NamedProperty | PrimitiveType) {
     }
 }
 
-function check(objectType: ObjectType, objectToCheck: any) {
+function check(objectType: ObjectType, objectOrIntrinsic: any) {
     try {
+        // objectOrIntrinsic may be an instrinsic that needs resolving.
+        const objectToCheck = resolveIntrinsic(objectOrIntrinsic);
+        console.dir({objectToCheck});
         // if we are checking against a resource or propertytype, it must be against
         // an object with subproperties.
         if ((objectType.type === 'RESOURCE') || (objectType.type === 'PROPERTY_TYPE')) {
@@ -1178,7 +798,7 @@ function check(objectType: ObjectType, objectToCheck: any) {
                     verify(isList, objectToCheck);
                     checkList(objectType as NamedProperty, objectToCheck);
                     break;
-                case KnownTypes.Arn:                    
+                case KnownTypes.Arn:
                     verify(isArn, objectToCheck);
                     break;
                 case KnownTypes.String:
@@ -1206,10 +826,10 @@ function check(objectType: ObjectType, objectToCheck: any) {
         }
     } catch (e) {
         if (e instanceof VerificationError) {
-            addError('crit', e.message+`, got ${util.inspect(objectToCheck)}`, placeInTemplate, objectType.resourceType);
+            addError('crit', e.message+`, got ${util.inspect(objectOrIntrinsic)}`, placeInTemplate, objectType.resourceType);
         } else {
             // generic error handler; let us keep checking what we can instead of crashing.
-            addError('crit', `Unexpected error: ${e.message} while checking ${util.inspect(objectToCheck)} against ${objectType}`, placeInTemplate, objectType.resourceType);
+            addError('crit', `Unexpected error: ${e.message} while checking ${util.inspect(objectOrIntrinsic)} against ${objectType}`, placeInTemplate, objectType.resourceType);
             console.error(e);
         }
     }
@@ -1436,7 +1056,7 @@ function checkComplexObject(objectType: ResourceType | NamedProperty | PropertyT
                 parentType: objectTypeName,
                 propertyName: subPropertyName
             } as NamedProperty;
-        
+
             check(subPropertyObjectType, propertyValue)
 
         } finally {

--- a/src/yamlSchema.ts
+++ b/src/yamlSchema.ts
@@ -1,0 +1,36 @@
+import yaml = require('js-yaml');
+
+export function functionTag(functionName: string) {
+    const splitFunctionName = functionName.split('::');
+    return splitFunctionName[splitFunctionName.length-1];
+}
+
+export default function buildYamlSchema() {
+    const intrinsicFunctions = require('../data/aws_intrinsic_functions.json');
+    const yamlTypes = [];
+    for (const fn in intrinsicFunctions) {
+        yamlTypes.push(...buildYamlTypes(fn));
+    }
+    return yaml.Schema.create(yamlTypes);
+}
+
+export type YamlKind = 'scalar' | 'mapping' | 'sequence';
+const kinds: YamlKind[] = ['scalar', 'mapping', 'sequence'];
+
+export function buildYamlTypes(fnName: string) {
+    return kinds.map((kind) => buildYamlType(fnName, kind));
+}
+
+export function buildYamlType(fnName: string, kind: YamlKind) {
+    const tagName = functionTag(fnName);
+    const tag = `!${tagName}`;
+
+    const constructFn = (fnName === 'Fn::GetAtt')
+        ? (data: any) => ({'Fn::GetAtt': data.split('.')})
+        : (data: any) => ({[fnName]: data});
+
+    return new yaml.Type(tag, {
+        kind,
+        construct: constructFn
+    });
+}

--- a/testData/valid/yaml/split.yaml
+++ b/testData/valid/yaml/split.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Resources:
+  WebServerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Desc
+      SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: '80'
+        IpProtocol: tcp
+        ToPort: '80'
+
+Outputs:
+  Simple:
+    Value: !Split ['-', 'asdf-fdsa']
+  Nested:
+    Value: !Split ['^', !Join ['_', [asdf^fdsa, asdf^fdsa]]]
+  SelectASplit:
+    Value: !Select
+      - 1,
+      - !Split ['@', 'a@b@c']


### PR DESCRIPTION
this is a work in progress but I am reasonably sure of the structure I'm proposing now.

Basic parsing method:
 1) replace all intrinsic objects (`{Fn::GetAtt: [args]}`) with an `BoundIntrinsic`. A `BoundIntrinsic` is equivalent to a bound function. It has pre-determined arguments and it can be called at a later time.
 2) run CheckResourceParameters. If this comes across a `BoundIntrinsic`, the `BoundIntrinsic` will be executed to check its result against the cfn schema.
 3) fire off any `BoundIntrinsics` that were not executed in 2), in order to find any errors (there are some things that can only be checked at function execution time).

Some things are a bit ugly - the `class`es for Intrinsic and BoundIntrinsic are a bit verbose and Java-looking, but they should at least be clear. I used actual bound functions with extra properties in an early prototype, but the workings of the way they were created was quite difficult to understand.

Feedback very welcome, tests don't pass yet and I'm still expecting to have to make major changes. :)