### PR TITLE
update cloudformation-js-yaml-schema to v0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/martysweet/cfn-lint/issues"
   },
   "dependencies": {
-    "cloudformation-js-yaml-schema": "0.3.0",
+    "cloudformation-js-yaml-schema": "0.3.5",
     "colors": "^1.2.1",
     "commander": "^2.15.0",
     "core-js": "^2.5.1",


### PR DESCRIPTION
This is a recommended update to address missing tags. 

#148 calls out some real issues - I hope to address these in the coming months or actively merging pull requests to get there. I'd like to thank @akdor1154 for bugging me to get those tags in. 

This version fixes missing tags, but won't help speedup or produce better errors to the user like suggested in #148 