### PR TITLE
Fn::Sub fixed nested Intrinsic functions and Literal Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Merge PR #167, adding support for SAM template validation
 
+### Fixed
+- Merge PR #197, fixing Fn::Sub fixed nested Intrinsic functions and Literal Values
+
 ## [1.8.1] - 2018-09-07
 ### Changed
 - Update CloudFormation specification (downloaded 05-Sep-2018) - version: 2.6.0

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -421,6 +421,14 @@ describe('validator', () => {
             expect(result['errors']['warn']).to.have.lengthOf(0);
         });
 
+        it('a sub with nested intrinsic values should result in validTemplate = true, 0 crit errors, no warnings', () => {
+            const input = 'testData/valid/yaml/valid_nested_intrinsic_subs.yaml';
+            let result = validator.validateFile(input);
+            expect(result).to.have.deep.property('templateValid', true);
+            expect(result['errors']['crit']).to.have.lengthOf(0);
+            expect(result['errors']['warn']).to.have.lengthOf(0);
+        });
+
     });
 
     describe('Fn::ImportValue', () => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1396,7 +1396,6 @@ function doIntrinsicSub(ref: any, key: string){
 
             // Check the given values are the correct types for an array style Sub, otherwise
             // throw errors.
-
             if(typeof toGet[0] == 'string'){
                 replacementStr = toGet[0];
             }else{

--- a/testData/valid/yaml/valid_nested_intrinsic_subs.yaml
+++ b/testData/valid/yaml/valid_nested_intrinsic_subs.yaml
@@ -1,0 +1,18 @@
+
+Parameters:
+  InputA:
+    Type: String
+    Default: testInput
+
+
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub
+            - service-${PartA}/${PartB}-${!LiteralValue}  # service-testInput/arn:aws:mock:region:123456789012:AnotherBucket-${LiteralValue}
+            - PartA: !Ref InputA
+              PartB: !GetAtt AnotherBucket.Arn
+
+  AnotherBucket:
+    Type: AWS::S3::Bucket


### PR DESCRIPTION
@ronkorving This fixes #195. I'm not too happy about the testability of this logic, and I feel it will be difficult to break out due to the intrinsicResolve dependencies... Any ideas @RazzM13, @akdor1154? 

Anyway, this should fix the issue for now. Will merge into master (if all happy) and release into v1.9.0, when it's unblocked.
