### PR TITLE
Add validateString API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Merge PR #213, add `validateString` API
 
 ## [1.9.2] - 2018-11-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ cfnLint.validateFile(fileName: string, options?: ValidationOptions): ValidationR
 ```
 Validates a file, and returns an ValidationResult with the results.
 
+```ts
+cfnLint.validateString(contents: string, fileName: string, options?: ValidationOptions): ValidationResult
+```
+Validates a string, and returns an ValidationResult with the results.
 
 ```ts
 cfnLint.validateJsonObject(object: any, options?: ValidationOptions): ValidationResult

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,17 @@ export function validateFile(fileName: string, options?: Partial<ValidationOptio
 }
 
 /**
+ * Synchronously validates a CloudFormation yaml or json string.
+ * @param contents
+ * @param filename
+ * @param options
+ */
+export function validateString(contents: string, filename: string, options?: Partial<ValidationOptions>): ValidationResult {
+  setupValidator(options);
+  return validator.validateString(contents, filename, options);
+}
+
+/**
  * Synchronously validates an object. The object should be what you
  * get from JSON.parse-ing or yaml.load-ing a CloudFormation template.
  * @param objectToValidate

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,26 +11,33 @@ export function openFile(path: string){
         throw Error(`Could not find file ${path}. Check the input path.`);
     }
 
+    return openString(fs.readFileSync(path, 'utf8'), path);
+
+};
+
+
+export function openString(contents: string, filename: string){
+
     // Try JSON loading
     try {
-        return openJson(path);
+        return openJson(contents);
     }catch (e){
 
     }
 
     // Try YAML loading
     try {
-        return openYaml(path);
+        return openYaml(contents, filename);
     }catch (e){
         throw Error(`Could not determine file type. Check your template is not malformed. ${e.message}`);
     }
 
-};
+}
 
-function openYaml(path: string){
+function openYaml(contents: string, path: string){
 
     // Try and load the Yaml
-    let yamlParse = yaml.safeLoad(fs.readFileSync(path, 'utf8'), {
+    let yamlParse = yaml.safeLoad(contents, {
         filename: path,
         schema: yamlSchema,
         onWarning: (warning) => {
@@ -47,8 +54,8 @@ function openYaml(path: string){
 
 }
 
-function openJson(path: string){
+function openJson(contents: string){
 
-    return JSON.parse(fs.readFileSync(path, 'utf8'));
+    return JSON.parse(contents);
 
 }

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -3,6 +3,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 import validator = require('../validator');
 import yaml = require('js-yaml');
+import fs = require('fs');
 
 import {samResources20161031} from '../samData';
 import {awsResources} from '../awsData';
@@ -1904,4 +1905,22 @@ describe('validator', () => {
             expect(result['errors']['crit']).to.have.lengthOf(0);
         });
     });
+
+  describe('validateString', () => {
+    it('a valid (1.json) template should return an object with validTemplate = true, no crit errors', () => {
+      const path = 'testData/valid/json/1.json';
+      const input = fs.readFileSync(path, 'utf8');
+      let result = validator.validateString(input, path);
+      expect(result).to.have.deep.property('templateValid', true);
+      expect(result['errors']['crit']).to.have.lengthOf(0);
+    });
+
+    it('a valid (1.yaml) template should return an object with validTemplate = true, no crit errors', () => {
+      const path = 'testData/valid/yaml/1.yaml';
+      const input = fs.readFileSync(path, 'utf8');
+      let result = validator.validateString(input, path);
+      expect(result).to.have.deep.property('templateValid', true);
+      expect(result['errors']['crit']).to.have.lengthOf(0);
+    });
+  });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -95,6 +95,13 @@ export function validateFile(path: string, options?: Partial<ValidateOptions>){
    return validateWorkingInput(options);
 };
 
+export function validateString(contents: string, filename: string, options?: Partial<ValidateOptions>){
+  // Convert to object, this will throw an exception on an error
+  workingInput = parser.openString(contents, filename);
+  // Let's go!
+  return validateWorkingInput(options);
+};
+
 export function validateJsonObject(obj: any, options?: Partial<ValidateOptions>){
     workingInput = obj;
     return validateWorkingInput(options);


### PR DESCRIPTION
Adds `validateString` API which is similar to `validateFile` but makes cfn-lint easier to use within other projects where the template exists only in memory.