### PR TITLE
Adding support for AWS::Batch::ComputeEnvironment.ComputeResources.AllocationStrategy

### DIFF
--- a/data/aws_resources_specification.json
+++ b/data/aws_resources_specification.json
@@ -4599,6 +4599,12 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-desiredvcpus",
           "PrimitiveType": "Integer",
           "UpdateType": "Mutable"
+        },
+        "AllocationStrategy": {
+          "Required": false,
+          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-allocationstrategy",
+          "PrimitiveType": "String",
+          "UpdateType": "Immutable"
         }
       }
     },


### PR DESCRIPTION
```
Resource: Resources > ComputeEnvironment > Properties > ComputeResources > AllocationStrategy
Message: AllocationStrategy is not a valid property of AWS::Batch::ComputeEnvironment.ComputeResources
Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html
```

add AWS::Batch::ComputeEnvironment.ComputeResources.AllocationStrategy property.