### PR TITLE
Fixing AWS::Batch::ComputeEnvironment.ComputeResources required props

### DIFF
--- a/data/aws_resources_specification.json
+++ b/data/aws_resources_specification.json
@@ -4546,7 +4546,7 @@
           "UpdateType": "Immutable"
         },
         "MinvCpus": {
-          "Required": true,
+          "Required": false,
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-minvcpus",
           "PrimitiveType": "Integer",
           "UpdateType": "Mutable"
@@ -4564,7 +4564,7 @@
           "UpdateType": "Immutable"
         },
         "InstanceRole": {
-          "Required": true,
+          "Required": false,
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-instancerole",
           "PrimitiveType": "String",
           "UpdateType": "Immutable"
@@ -4572,7 +4572,7 @@
         "InstanceTypes": {
           "PrimitiveItemType": "String",
           "Type": "List",
-          "Required": true,
+          "Required": false,
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-instancetypes",
           "UpdateType": "Immutable"
         },


### PR DESCRIPTION
Fixing AWS::Batch::ComputeEnvironment.ComputeResources required properties.
**MinvCpus, InstanceRole, InstanceTypes** are no longer required by AWS