### PR TITLE
Fix null reference exception when using AutoPublishAlias

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "js-yaml": "^3.13.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.4",
+    "@types/chai": "~4.0.4",
     "@types/clone": "^0.1.30",
     "@types/colors": "~1.1.3",
     "@types/commander": "^2.11.0",
     "@types/js-yaml": "^3.12.0",
     "@types/mocha": "^2.2.44",
-    "@types/node": "^8.0.50",
+    "@types/node": "~8.0.50",
     "@types/opn": "^3.0.28",
     "@types/source-map-support": "^0.4.0",
     "@types/winston": "^2.3.7",

--- a/src/test/validatorTest.ts
+++ b/src/test/validatorTest.ts
@@ -1945,5 +1945,14 @@ describe('validator', () => {
             expect(result).to.have.deep.property('templateValid', true);
             expect(result['errors']['crit']).to.have.lengthOf(0);
         });
+
+        // This is failed because of the schema is outdated (since we *can* have an object instead of string for CodeUri)
+        it('an valid (6_unsupported_code_uri_autopublishalias.json) template because of outdated schema', () => {
+            const input = require('../../testData/invalid/json/6_unsupported_code_uri_autopublishalias.json');
+            let result = validator.validateJsonObject(input);
+            console.log(JSON.stringify(result));
+            expect(result).to.have.deep.property('templateValid', false);
+            expect(result['errors']['crit']).to.have.lengthOf(1);
+        });
     });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -552,6 +552,7 @@ function doSAMTransform(baseType:string, type: string, name: string, template: a
                     let codeDict: any = null;
 
                     if (!!parentProperties && parentProperties.hasOwnProperty('CodeUri')) {
+                      codeDict = {};
                       if (parentProperties['CodeUri'].hasOwnProperty('Bucket')) {
                         codeDict['S3Bucket'] = parentProperties['CodeUri']['Bucket'];
                       }
@@ -562,7 +563,7 @@ function doSAMTransform(baseType:string, type: string, name: string, template: a
                         codeDict['S3ObjectVersion'] = parentProperties['CodeUri']['Version'];
                       }
                     } else if (!!parentProperties && parentProperties.hasOwnProperty('InlineCode')) {
-                      codeDict['ZipFile'] = parentProperties['InlineCode'];
+                      codeDict = { 'ZipFile': parentProperties['InlineCode'] };
                     } else {
                       // TODO: perhaps raise validation error if neither CodeUri or InlineCode have been provided
                     }

--- a/testData/invalid/json/6_unsupported_code_uri_autopublishalias.json
+++ b/testData/invalid/json/6_unsupported_code_uri_autopublishalias.json
@@ -1,0 +1,31 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Lambda resource stack creation using Amplify CLI",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Parameters": {
+    "env": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "LambdaFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Metadata": {
+        "aws:asset:path": "./src",
+        "aws:asset:property": "Code"
+      },
+      "Properties": {
+        "Handler": "index.handler",
+        "FunctionName": "myfunction",
+        "Runtime": "nodejs12.x",
+        "Timeout": 150,
+        "MemorySize": 512,
+        "AutoPublishAlias": "customalias",
+        "CodeUri": {
+          "Bucket": "amplify-myfunction-222350-deployment",
+          "Key": "amplify-builds/myfunction-3c656d2552663b6f216e-build.zip"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The current code has an issue by not initializing properly the variable where we want to store the code-related information, so we get a null reference exception:

```
TypeError: Cannot set property 'S3Bucket' of null
at doSAMTransform (lib\validator.js:595:62)
at applyTemplatePropertyOverrides (lib\validator.js:714:5)
at applyTemplateTypeOverrides (lib\validator.js:745:21)
at applyTemplateOverrides (lib\validator.js:798:33)
at validateWorkingInput (lib\validator.js:196:5)
at Object.validateJsonObject (lib\validator.js:98:12)
at Context.<anonymous> (lib\test\validatorTest.js:1753:36)
at processImmediate (internal/timers.js:456:21)
```

This happens when using this library from the amplify-cli project, so we're actually blocked by pushing a perfectly valid schema to AWS.

I took the liberty of also fixing the build by pinning some `@types` packages, see the related (similar) issue.